### PR TITLE
Switch to latest LibFLAC and LibALSA

### DIFF
--- a/hack/init_linux_env.sh
+++ b/hack/init_linux_env.sh
@@ -6,8 +6,8 @@ set -o nounset
 set -o pipefail
 
 BUILD_HOST=${BUILD_HOST:-"x86_64-linux-gnu"}
-LIBFLAC_VER=1.3.3
-LIBALSA_VER=1.2.2
+LIBFLAC_VER=1.4.2
+LIBALSA_VER=1.2.8
 
 # install libflac
 cd /tmp


### PR DESCRIPTION
尝试向 Archlinux arm 移植 go-musicfox 但 Archlinux arm repo并未提供FLAC1.3包(libFLAC.so.8).

使用Flac1.4.2(libFLAC.so.12)可成功编译.

环境:6.2.12-1-MANJARO; go1.20.3 linux/amd64