### PR TITLE
fix: opening the QR code image fails when the MUSICFOX_ROOT environment variable is set in Windows

### DIFF
--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/anhoder/foxful-cli/util"
 	"github.com/gookit/gcli/v2"
@@ -17,7 +17,7 @@ func NewConfigCommand() *gcli.Command {
 		Name:   "config",
 		UseFor: "Print configuration file to be loaded",
 		Func: func(_ *gcli.Command, _ []string) error {
-			var configPath = util.SetFgStyle(path.Join(utils.GetLocalDataDir(), types.AppIniFile), termenv.ANSICyan)
+			var configPath = util.SetFgStyle(filepath.Join(utils.GetLocalDataDir(), types.AppIniFile), termenv.ANSICyan)
 			fmt.Printf("Loaded Configuration File:\n\t%s\n", configPath)
 			return nil
 		},

--- a/internal/player/beep_player.go
+++ b/internal/player/beep_player.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -93,7 +93,7 @@ func (p *beepPlayer) listen() {
 		panic(err)
 	}
 
-	cacheFile := path.Join(utils.GetLocalDataDir(), "music_cache")
+	cacheFile := filepath.Join(utils.GetLocalDataDir(), "music_cache")
 	for {
 		select {
 		case <-p.close:

--- a/internal/ui/login_page.go
+++ b/internal/ui/login_page.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"log"
+	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -391,6 +393,9 @@ func (l *LoginPage) loginByQRCode() (model.Page, tea.Cmd) {
 		path, err := utils.GenQRCode("qrcode.png", url)
 		if err != nil {
 			return errHandler(err)
+		}
+		if runtime.GOOS == "windows" {
+			path = filepath.FromSlash(path)
 		}
 		_ = open.Start(path)
 		l.tips = util.SetFgStyle("请扫描二维码(MUSICFOX_ROOT/qrcode.png)登录后，点击「继续」", termenv.ANSIBrightRed)

--- a/internal/ui/login_page.go
+++ b/internal/ui/login_page.go
@@ -2,8 +2,6 @@ package ui
 
 import (
 	"log"
-	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -393,9 +391,6 @@ func (l *LoginPage) loginByQRCode() (model.Page, tea.Cmd) {
 		path, err := utils.GenQRCode("qrcode.png", url)
 		if err != nil {
 			return errHandler(err)
-		}
-		if runtime.GOOS == "windows" {
-			path = filepath.FromSlash(path)
 		}
 		_ = open.Start(path)
 		l.tips = util.SetFgStyle("请扫描二维码(MUSICFOX_ROOT/qrcode.png)登录后，点击「继续」", termenv.ANSIBrightRed)

--- a/internal/ui/netease.go
+++ b/internal/ui/netease.go
@@ -3,7 +3,7 @@ package ui
 import (
 	"encoding/json"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"time"
@@ -64,7 +64,7 @@ func (n *Netease) InitHook(_ *model.App) {
 	projectDir := utils.GetLocalDataDir()
 
 	// 全局文件Jar
-	cookieJar, _ := cookiejar.NewFileJar(path.Join(projectDir, "cookie"), nil)
+	cookieJar, _ := cookiejar.NewFileJar(filepath.Join(projectDir, "cookie"), nil)
 	util.SetGlobalCookieJar(cookieJar)
 
 	// DBManager初始化
@@ -142,10 +142,10 @@ func (n *Netease) InitHook(_ *model.App) {
 				localDir := utils.GetLocalDataDir()
 
 				// 删除旧notifier
-				_ = os.RemoveAll(path.Join(localDir, "musicfox-notifier.app"))
+				_ = os.RemoveAll(filepath.Join(localDir, "musicfox-notifier.app"))
 
 				// 删除旧logo
-				_ = os.Remove(path.Join(localDir, types.DefaultNotifyIcon))
+				_ = os.Remove(filepath.Join(localDir, types.DefaultNotifyIcon))
 
 				extInfo.StorageVersion = types.AppVersion
 				_ = table.SetByKVModel(extInfo, extInfo)

--- a/internal/ui/operate.go
+++ b/internal/ui/operate.go
@@ -3,7 +3,7 @@ package ui
 import (
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 
 	"github.com/anhoder/foxful-cli/model"
@@ -126,7 +126,7 @@ func logout() {
 		Url:     types.AppGithubUrl,
 		GroupId: types.GroupID,
 	})
-	_ = os.Remove(path.Join(utils.GetLocalDataDir(), "cookie"))
+	_ = os.Remove(filepath.Join(utils.GetLocalDataDir(), "cookie"))
 }
 
 // likeSelectedSong like/unlike selected song

--- a/utils/log.go
+++ b/utils/log.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 )
 
 var (
@@ -23,7 +23,7 @@ func Logger() *log.Logger {
 
 	dir := GetLocalDataDir()
 	var err error
-	logWriter, err = os.OpenFile(path.Join(dir, "musicfox.log"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
+	logWriter, err = os.OpenFile(filepath.Join(dir, "musicfox.log"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
 	if err != nil {
 		return log.Default()
 	}

--- a/utils/notifier.go
+++ b/utils/notifier.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -23,7 +23,7 @@ type osxNotificator struct {
 
 func (o osxNotificator) getNotifierCmd() string {
 	localDir := GetLocalDataDir()
-	notifierPath := path.Join(localDir, "musicfox-notifier.app")
+	notifierPath := filepath.Join(localDir, "musicfox-notifier.app")
 	if _, err := os.Stat(notifierPath); os.IsNotExist(err) {
 		err = CopyDirFromEmbed("embed/musicfox-notifier.app", notifierPath)
 		if err != nil {
@@ -126,9 +126,9 @@ func Notify(content NotifyContent) {
 
 	if runtime.GOOS != "darwin" {
 		localDir := GetLocalDataDir()
-		content.Icon = path.Join(localDir, configs.ConfigRegistry.Main.NotifyIcon)
+		content.Icon = filepath.Join(localDir, configs.ConfigRegistry.Main.NotifyIcon)
 		if _, err := os.Stat(content.Icon); os.IsNotExist(err) {
-			content.Icon = path.Join(localDir, types.DefaultNotifyIcon)
+			content.Icon = filepath.Join(localDir, types.DefaultNotifyIcon)
 			// 写入logo文件
 			err = CopyFileFromEmbed("embed/logo.png", content.Icon)
 			if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path"
-	filepathPkg "path/filepath"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -44,14 +44,14 @@ func GetLocalDataDir() string {
 		if nil != err {
 			panic("未获取到本地数据目录：" + err.Error())
 		}
-		projectDir = path.Join(configDir, types.AppLocalDataDir)
+		projectDir = filepath.Join(configDir, types.AppLocalDataDir)
 	}
 
 	// 如果 projectDir 不存在且未设置 MUSICFOX_ROOT 环境变量
 	// 则尝试从默认路径迁移配置
 	if !FileOrDirExists(projectDir) {
 		home, _ := os.UserHomeDir()
-		oldPath := path.Join(home, "."+types.AppLocalDataDir)
+		oldPath := filepath.Join(home, "."+types.AppLocalDataDir)
 		if !FileOrDirExists(oldPath) {
 			_ = os.MkdirAll(projectDir, os.ModePerm)
 			return projectDir
@@ -100,7 +100,7 @@ func BinToID(bin []byte) uint64 {
 // LoadIniConfig 加载ini配置信息
 func LoadIniConfig() {
 	projectDir := GetLocalDataDir()
-	configFile := path.Join(projectDir, types.AppIniFile)
+	configFile := filepath.Join(projectDir, types.AppIniFile)
 	if !FileOrDirExists(configFile) {
 		_ = CopyFileFromEmbed("embed/go-musicfox.ini", configFile)
 	}
@@ -193,7 +193,7 @@ func (e FileExistsError) Error() string {
 func GetCacheDir() string {
 	cacheDir := configs.ConfigRegistry.Main.CacheDir
 	if cacheDir == "" {
-		cacheDir = path.Join(GetLocalDataDir(), "cache")
+		cacheDir = filepath.Join(GetLocalDataDir(), "cache")
 	}
 	return cacheDir
 }
@@ -201,13 +201,13 @@ func GetCacheDir() string {
 func GetDownloadDir() string {
 	downloadDir := configs.ConfigRegistry.Main.DownloadDir
 	if downloadDir == "" {
-		downloadDir = path.Join(GetLocalDataDir(), "download")
+		downloadDir = filepath.Join(GetLocalDataDir(), "download")
 	}
 	return downloadDir
 }
 
 func DownloadFile(url, filename, dirname string) error {
-	targetFilename := path.Join(dirname, filename)
+	targetFilename := filepath.Join(dirname, filename)
 	if !FileOrDirExists(dirname) {
 		_ = os.MkdirAll(dirname, os.ModePerm)
 	}
@@ -261,7 +261,7 @@ func getCacheUri(songId int64) (uri string, ok bool) {
 	for i := len(files) - 1; i >= 0; i-- {
 		file := files[i]
 		if strings.HasPrefix(file.Name(), strconv.FormatInt(songId, 10)) {
-			uri = path.Join(cacheDir, file.Name())
+			uri = filepath.Join(cacheDir, file.Name())
 			ok = true
 			return
 		}
@@ -288,7 +288,7 @@ func CopyCachedSong(song structs.Song) error {
 	// Windows Linux 均不允许文件名中出现 / \ 替换为 _
 	filename = strings.Replace(filename, "/", "_", -1)
 	filename = strings.Replace(filename, "\\", "_", -1)
-	targetFilename := path.Join(downloadDir, filename)
+	targetFilename := filepath.Join(downloadDir, filename)
 
 	if _, err := os.Stat(targetFilename); err == nil {
 		return FileExistsError{path: targetFilename}
@@ -385,7 +385,7 @@ func downloadMusic(url, musicType string, song structs.Song, downloadDir string)
 	if err != nil {
 		return err
 	}
-	file, _ := os.OpenFile(path.Join(downloadDir, filename), os.O_RDWR, os.ModePerm)
+	file, _ := os.OpenFile(filepath.Join(downloadDir, filename), os.O_RDWR, os.ModePerm)
 	SetSongTag(file, song)
 	return nil
 }
@@ -472,7 +472,7 @@ func CacheMusic(song structs.Song, url string, musicType string, quality service
 		errHandler(err)
 		return
 	}
-	file, err := os.OpenFile(path.Join(cacheDir, filename), os.O_RDWR, os.ModePerm)
+	file, err := os.OpenFile(filepath.Join(cacheDir, filename), os.O_RDWR, os.ModePerm)
 	if err != nil {
 		return
 	}
@@ -604,8 +604,8 @@ func CopyDirFromEmbed(src, dst string) error {
 		return err
 	}
 	for _, fd := range fds {
-		srcfp := path.Join(src, fd.Name())
-		dstfp := path.Join(dst, fd.Name())
+		srcfp := filepath.Join(src, fd.Name())
+		dstfp := filepath.Join(dst, fd.Name())
 
 		if fd.IsDir() {
 			if err = CopyDirFromEmbed(srcfp, dstfp); err != nil {
@@ -622,12 +622,11 @@ func CopyDirFromEmbed(src, dst string) error {
 
 func GenQRCode(filename, content string) (string, error) {
 	localDir := GetLocalDataDir()
-	filepath := path.Join(localDir, filename)
-	if err := qrcode.WriteFile(content, qrcode.Medium, 256, filepath); err != nil {
+	qrcodePath := filepath.Join(localDir, filename)
+	if err := qrcode.WriteFile(content, qrcode.Medium, 256, qrcodePath); err != nil {
 		return "", err
 	}
-	filepath = filepathPkg.FromSlash(filepath)
-	return filepath, nil
+	return qrcodePath, nil
 }
 
 func WebUrlOfPlaylist(playlistId int64) string {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	filepathPkg "path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -625,6 +626,7 @@ func GenQRCode(filename, content string) (string, error) {
 	if err := qrcode.WriteFile(content, qrcode.Medium, 256, filepath); err != nil {
 		return "", err
 	}
+	filepath = filepathPkg.FromSlash(filepath)
 	return filepath, nil
 }
 


### PR DESCRIPTION
当设置了 MUSICFOX_ROOT 时。例如 ` SET MUSICFOX_ROOT=.go-musicfox`

open.Start(".go-musicfox/qrcode.png") 会失败。需要转换成 Windows 路径。