### PR TITLE
fix: make install error

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -20,7 +20,7 @@ BUILD_TARGET=${BUILD_TARGET:-""}
 BUILD_TAGS=${BUILD_TAGS:-""}
 
 if [[ "${ACTION}" = "build" ]]; then
-	BUILD_TARGET="${ROOT}/bin/musicfox"
+	BUILD_TARGET="-o ${ROOT}/bin/musicfox"
 fi
 
 VERSION_INFO=$(mktemp)
@@ -37,5 +37,5 @@ LDFLAGS=${LDFLAGS}" -X ${INJECT_PACKAGE}.BuildTags=${BUILD_TAGS}"
 
 CGO_ENABLED=1 GOOS=${BUILD_GOOS} GOARCH=${BUILD_GOARCH} ${GOBINARY} "${ACTION}" \
 	-tags "${BUILD_TAGS}" \
-	-ldflags "${LDFLAGS}" -o "${BUILD_TARGET}" \
+	-ldflags "${LDFLAGS}" ${BUILD_TARGET} \
 	"${ROOT}/cmd/musicfox.go"


### PR DESCRIPTION
when ```make install``` following error occurs
```
flag provided but not defined: -o
usage: go install [build flags] [packages]
Run 'go help install' for details.
make: *** [Makefile:28：install] 错误 2
```
It's seem to be there is no '-o' flag in 'go install' command.