### PR TITLE
README添加flathub链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,13 @@ $ brew install anhoder/go-musicfox/go-musicfox  // 指定 --head 使用master代
 $ brew unlink musicfox && brew link --overwrite go-musicfox
 ```
 
-#### 3. 直接下载
+#### 3. 通过 Flatpak 安装
+
+<a href='https://flathub.org/apps/io.github.go_musicfox.go-musicfox'>
+    <img width='120' alt='Download on Flathub' src='https://flathub.org/api/badge?locale=zh-Hans'/>
+</a>
+
+#### 4. 直接下载
 
 在 [Release](https://github.com/go-musicfox/go-musicfox/releases/latest) 下载 Linux 的可执行文件。
 


### PR DESCRIPTION
Resolve #329

最基本的登录和播放音乐都能用，但是flatpak版目前还有一些小问题，已知的有：开启时一定跳更新提示，配置文件的位置和默认的不一样，桌面通知找不到图标（在KDE上用的是系统的默认图标），以及和系统的播放器配合不佳。

要是作者觉得这些问题影响使用，暂时不merge也可以。这几个问题有空了会慢慢修的。