### PR TITLE
更新appdata文件

### DIFF
--- a/deploy/io.github.go_musicfox.go-musicfox.appdata.xml
+++ b/deploy/io.github.go_musicfox.go-musicfox.appdata.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="console-application">
   <id>io.github.go_musicfox.go-musicfox</id>
-  
+
   <name>Musicfox</name>
   <developer_name>anhoder</developer_name>
   <summary>Terminal music player for Netease Cloud Music</summary>
   <summary xml:lang="zh_CN">网易云音乐命令行客户端。</summary>
-
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
-  
+
   <!--Not possible to control this application with mouse or touch since it only has a TUI-->
   <recommends>
     <control>keyboard</control>
     <internet>always</internet>
   </recommends>
-
   <provides>
     <binary>musicfox</binary>
   </provides>
-  
+
+  <content_rating type="oars-1.1" />
   <description>
-    <p>A Netease Cloud Music client on the terminal.</p>
+    <p>A Netease Cloud Music client on the terminal. Simplified Chiense is the only supported language.</p>
+    <p xml:lang="zh_CN">网易云音乐命令行客户端。仅支持简体中文。</p>
   </description>
-  
+
   <launchable type="desktop-id">io.github.go_musicfox.go-musicfox.desktop</launchable>
   <screenshots>
     <screenshot type="default">
@@ -31,14 +31,15 @@
       <caption>Main interface</caption>
     </screenshot>
   </screenshots>
-
   <url type="bugtracker">https://github.com/go-musicfox/go-musicfox/issues</url>
   <url type="homepage">https://github.com/go-musicfox/go-musicfox</url>
-  
+
   <releases>
+    <release version="4.6.0" date="2024-12-01" type="stable">
+      <url type="details">https://github.com/go-musicfox/go-musicfox/releases/tag/v4.6.0</url>
+    </release>
     <release version="4.5.7" date="2024-11-02" type="stable">
       <url type="details">https://github.com/go-musicfox/go-musicfox/releases/tag/v4.5.7</url>
     </release>
   </releases>
-
 </component>


### PR DESCRIPTION
我跟flathub的人交流了一下，他们建议在发新版本的时候在`releases`里面加上新的`release`标签。但是如果您不想把发版过程搞得太麻烦或者忘记了更新，我可以在[下游](https://github.com/flathub/io.github.go_musicfox.go-musicfox) patch appdata文件并加上新版本。