### PR TITLE
修复flatpak下的通知图标

### DIFF
--- a/utils/notify/notification.go
+++ b/utils/notify/notification.go
@@ -126,7 +126,10 @@ func Notify(content NotifyContent) {
 		AppName: types.AppName,
 	})
 
-	if runtime.GOOS != "darwin" {
+	// Hard code flatpak icon directory
+	if os.Getenv("container") == "flatpak" {
+		content.Icon = "/app/share/icons/hicolor/512x512/apps/io.github.go_musicfox.go-musicfox.png"
+	} else if runtime.GOOS != "darwin" {
 		localDir := app.DataRootDir()
 		content.Icon = filepath.Join(localDir, configs.ConfigRegistry.Main.NotifyIcon)
 		if _, err := os.Stat(content.Icon); os.IsNotExist(err) {


### PR DESCRIPTION
由于flatpak沙盒的限制，默认的通知推送方法（`notify-send`）无法正确展示图标（flathub/io.github.go_musicfox.go-musicfox#4）。我在 flathub/io.github.go_musicfox.go-musicfox#7 的 `icon.patch` 文件里打了个补丁，但是如果上游有改动就又要改补丁，所以就干脆提交一个PR。如果不合并也没关系，只要`notification.go`这个文件不变就没有更新补丁的必要。

说实话，这种把路径写死的写法挺丑陋的，但是放在别处的图标（比如`.config`或者`$HOME`）没法显示，所以只能用绝对路径了。