### PR TITLE
feat: allow second instance of musicfox to share the database

### DIFF
--- a/internal/storage/local_db.go
+++ b/internal/storage/local_db.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -13,6 +14,22 @@ import (
 
 type LocalDB struct {
 	*bbolt.DB
+	isTemporary bool
+	path        string
+}
+
+func (m *LocalDB) Close() error {
+	err := m.DB.Close()
+	if err != nil {
+		return err
+	}
+	if m.isTemporary {
+		err := os.Remove(m.path)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // NewLocalDB 创建本地数据库
@@ -23,26 +40,65 @@ func NewLocalDB(dbName string) (*LocalDB, error) {
 	if _, err := os.Stat(dbDir); err != nil {
 		_ = os.MkdirAll(dbDir, 0755)
 	}
-	path := fmt.Sprintf("%s/%s.db", dbDir, dbName)
 
+	temporaryDB := false
+	path := fmt.Sprintf("%s/%s.db", dbDir, dbName)
 	options := bbolt.DefaultOptions
 	options.Timeout = 500 * time.Millisecond
-	boltDB, err := bbolt.Open(path, 0600, options)
-	if err != nil {
-		return nil, err
-	}
 
-	db := &LocalDB{
-		DB: boltDB,
+	for {
+		boltDB, err := bbolt.Open(path, 0600, options)
+		if err == nil {
+			// Success. Just return the DB.
+			db := &LocalDB{
+				DB:          boltDB,
+				isTemporary: temporaryDB,
+				path:        path,
+			}
+			return db, nil
+		}
+		// If the default database can't be opened because of a timeout, it is likely because another instance
+		// of musicfox is already running and has a file lock on the default database. This error is recoverable, and
+		// we can try copy the content of the database to a temporary file and open the temporary file as our database
+		// instead. Otherwise, it is not possible to recover from this error. We just return nil.
+		recoverableError := errors.Is(err, bbolt.ErrTimeout) && !temporaryDB
+		if !recoverableError {
+			return nil, err
+		}
+		sourceFile, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		defer sourceFile.Close()
+		targetFile, err := os.CreateTemp("", fmt.Sprintf("%s*.db", dbName))
+		if err != nil {
+			return nil, err
+		}
+		defer targetFile.Close()
+		_, err = io.Copy(targetFile, sourceFile)
+		if err != nil {
+			return nil, err
+		}
+		// Try to open the database again with the new file
+		path = targetFile.Name()
+		temporaryDB = true
 	}
-
-	return db, err
 }
 
 var DBManager *LocalDBManager
 
 type LocalDBManager struct {
 	localDBs map[string]*LocalDB
+}
+
+func (dm *LocalDBManager) Close() error {
+	for _, db := range dm.localDBs {
+		err := db.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // GetDBFromCache 从缓存中获取 LocalDB


### PR DESCRIPTION
（部分）修复了#345

我写了两个`Close`用来删除临时数据库，但是不太确定怎么在程序退出的时候自动用`Close`清理临时文件，所以最后没有用上。

在Linux/MacOS下，临时数据位于`/tmp`，重启后就自动清空了，没什么用`Close`的必要。Windows更麻烦一些，我记着临时文件夹需要手动清空。不过同时开两个musicfox的情况挺罕见的，多几个临时文件影响应该不大。