### PR TITLE
支持在桌面通知中使用专辑封面作为图片

### DIFF
--- a/internal/configs/main.go
+++ b/internal/configs/main.go
@@ -14,6 +14,7 @@ type MainOptions struct {
 	ShowLyricTrans         bool                     // 显示歌词翻译
 	ShowNotify             bool                     // 显示通知
 	NotifyIcon             string                   // logo 图片名
+	NotifyAlbumCover       bool                     // 通知显示专辑封面
 	PProfPort              int                      // pprof端口
 	AltScreen              bool                     // AltScreen显示模式
 	EnableMouseEvent       bool                     // 启用鼠标事件

--- a/internal/configs/registry.go
+++ b/internal/configs/registry.go
@@ -77,6 +77,7 @@ func NewRegistryWithDefault() *Registry {
 			ShowLyricTrans:   true,
 			ShowNotify:       true,
 			NotifyIcon:       types.DefaultNotifyIcon,
+			NotifyAlbumCover: false,
 			PProfPort:        types.MainPProfPort,
 			AltScreen:        true,
 			EnableMouseEvent: true,
@@ -157,6 +158,7 @@ func NewRegistryFromIniFile(filepath string) *Registry {
 	registry.Main.ShowLyricTrans = ini.Bool("main.showLyricTrans", true)
 	registry.Main.ShowNotify = ini.Bool("main.showNotify", true)
 	registry.Main.NotifyIcon = ini.String("main.notifyIcon", types.DefaultNotifyIcon)
+	registry.Main.NotifyAlbumCover = ini.Bool("main.notifyAlbumCover", false)
 	registry.Main.PProfPort = ini.Int("main.pprofPort", types.MainPProfPort)
 	registry.Main.AltScreen = ini.Bool("main.altScreen", true)
 	registry.Main.EnableMouseEvent = ini.Bool("main.enableMouseEvent", true)

--- a/utils/filex/embed/go-musicfox.ini
+++ b/utils/filex/embed/go-musicfox.ini
@@ -39,8 +39,10 @@ songLevel=higher
 # primaryColor=random
 # 经典网易云音乐红
 primaryColor="#ea403f"
-# windows,linux下的通知图标
+# windows,linux下的默认通知图标
 notifyIcon="logo.png"
+# windows,linux下是否使用歌曲专辑封面作为通知图标（如为否则使用默认通知图标）
+notifyAlbumCover=false
 # 是否显示歌词
 showLyric=true
 # 歌词偏移 ms

--- a/utils/notify/notification.go
+++ b/utils/notify/notification.go
@@ -2,11 +2,15 @@ package notify
 
 import (
 	"fmt"
+	"hash/fnv"
+	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/go-musicfox/notificator"
@@ -127,19 +131,94 @@ func Notify(content NotifyContent) {
 	})
 
 	if runtime.GOOS != "darwin" {
-		localDir := app.DataRootDir()
-		content.Icon = filepath.Join(localDir, configs.ConfigRegistry.Main.NotifyIcon)
-		if _, err := os.Stat(content.Icon); os.IsNotExist(err) {
-			content.Icon = filepath.Join(localDir, types.DefaultNotifyIcon)
-			// 写入logo文件
-			err = filex.CopyFileFromEmbed("embed/logo.png", content.Icon)
+		// On non-macOS operating systems, only one image is allowed per notification.
+		// The user can choose to send an album cover in notifications or use the default musicfox icon.
+		if configs.ConfigRegistry.Main.NotifyAlbumCover {
+			err := useAlbumCover(&content)
+			// fall back to default icon
 			if err != nil {
-				log.Printf("copy logo.png failed, err: %+v", errors.WithStack(err))
+				useAppIcon(&content)
 			}
-		} else if err != nil {
-			log.Printf("logo.png status err: %+v", errors.WithStack(err))
+		} else {
+			useAppIcon(&content)
 		}
 	}
 
 	_ = notify.Push(notificator.UrNormal, content.Title, content.Text, content.Icon, content.Url, content.GroupId)
+}
+
+func useAlbumCover(content *NotifyContent) error {
+	iconUrl := content.Icon
+	localFile, err := getLocalFileName(iconUrl)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(localFile); err == nil {
+		content.Icon = localFile
+		return nil
+	} else if errors.Is(err, os.ErrNotExist) {
+		response, e := http.Get(iconUrl)
+		if e != nil {
+			return e
+		}
+		defer response.Body.Close()
+		file, err := os.Create(localFile)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		_, err = io.Copy(file, response.Body)
+		if err != nil {
+			return err
+		}
+		content.Icon = localFile
+		return nil
+	} else {
+		return err
+	}
+}
+
+func getLocalFileName(icon string) (string, error) {
+	icon = strings.ReplaceAll(icon, "http://", "https://")
+	if !strings.Contains(icon, "https://") {
+		return "", errors.New("Icon does not seem to be a valid url: " + icon)
+	}
+	// Hash the url to get a file name
+	h := fnv.New64a()
+	_, err := h.Write([]byte(icon))
+	if err != nil {
+		return "", err
+	}
+	hashed := strconv.FormatUint(h.Sum64(), 36)
+	fileName := hashed + ".jpg"
+	// Use /tmp/musicfox to temporarily store the album cover
+	localDir := filepath.Join(os.TempDir(), "musicfox")
+	err = os.MkdirAll(localDir, 0777)
+	if err != nil {
+		return "", err
+	}
+	localFile := filepath.Join(localDir, fileName)
+	return localFile, nil
+}
+
+func useAppIcon(content *NotifyContent) {
+	// Flatpak notifications won't work if we use the default logo directory. Use this hard-coded one instead.
+	// See https://github.com/flathub/io.github.go_musicfox.go-musicfox/issues/4
+	if os.Getenv("container") == "flatpak" {
+		content.Icon = "/app/share/icons/hicolor/512x512/apps/io.github.go_musicfox.go-musicfox.png"
+		return
+	}
+	localDir := app.DataRootDir()
+	content.Icon = filepath.Join(localDir, configs.ConfigRegistry.Main.NotifyIcon)
+	if _, err := os.Stat(content.Icon); os.IsNotExist(err) {
+		content.Icon = filepath.Join(localDir, types.DefaultNotifyIcon)
+		// 写入logo文件
+		err = filex.CopyFileFromEmbed("embed/logo.png", content.Icon)
+		if err != nil {
+			log.Printf("copy logo.png failed, err: %+v", errors.WithStack(err))
+		}
+	} else if err != nil {
+		log.Printf("logo.png status err: %+v", errors.WithStack(err))
+	}
 }


### PR DESCRIPTION
Fix #229。增加了一个可调的设置（`main.notifyAlbumCover`）。大概思路是遇到图片url就把它下载到临时文件夹，然后用在通知里。文件名是url的hash，所以可以避免重复下载。即使考虑到[生日问题](https://zh.wikipedia.org/zh-hans/%E7%94%9F%E6%97%A5%E5%95%8F%E9%A1%8C)，不同url的hash相同的概率也很低，至少应对几千首歌是没问题的。

顺便塞了个flatpak相关的私货（来自#352）
```
if os.Getenv("container") == "flatpak" {
    content.Icon = "/app/share/icons/hicolor/512x512/apps/io.github.go_musicfox.go-musicfox.png"
    return
}
```
要不然等发新版本之后又要更新flatpak的patch。