### PR TITLE
feat: support toggling last.fm scrobble status

### DIFF
--- a/internal/configs/lastfm.go
+++ b/internal/configs/lastfm.go
@@ -1,6 +1,7 @@
 package configs
 
 type LastfmOptions struct {
-	Key    string // API Key
-	Secret string // API Shared Secret
+	Key      string // API Key
+	Secret   string // API Shared Secret
+	Scrobble bool   // 是否启用，默认 true
 }

--- a/internal/configs/registry.go
+++ b/internal/configs/registry.go
@@ -99,6 +99,7 @@ func NewRegistryWithDefault() *Registry {
 		Lastfm: LastfmOptions{
 			Key:    types.LastfmKey,
 			Secret: types.LastfmSecret,
+			Scrobble: true,
 		},
 	}
 
@@ -218,6 +219,7 @@ func NewRegistryFromIniFile(filepath string) *Registry {
 	// Lastfm
 	registry.Lastfm.Key = ini.String("lastfm.key", types.LastfmKey)
 	registry.Lastfm.Secret = ini.String("lastfm.secret", types.LastfmSecret)
+	registry.Lastfm.Scrobble = ini.Bool("lastfm.scrobble", true)
 
 	return registry
 }

--- a/internal/ui/lastfm.go
+++ b/internal/ui/lastfm.go
@@ -6,6 +6,7 @@ import (
 	"github.com/anhoder/foxful-cli/model"
 	"github.com/skratchdot/open-golang/open"
 
+	"github.com/go-musicfox/go-musicfox/internal/configs"
 	"github.com/go-musicfox/go-musicfox/internal/storage"
 )
 
@@ -31,8 +32,15 @@ func (m *Lastfm) MenuViews() []model.MenuItem {
 			{Title: "去授权"},
 		}
 	}
+
+	subtitle := "[已启用]"
+	if !configs.ConfigRegistry.Lastfm.Scrobble {
+		subtitle = "[未启用]"
+	}
+
 	return []model.MenuItem{
 		{Title: "查看用户信息"},
+		{Title: "上报", Subtitle: subtitle},
 		{Title: "清除授权"},
 	}
 }
@@ -45,6 +53,10 @@ func (m *Lastfm) SubMenu(_ *model.App, index int) model.Menu {
 	case 0:
 		_ = open.Start(m.netease.lastfmUser.Url)
 	case 1:
+		configs.ConfigRegistry.Lastfm.Scrobble = !configs.ConfigRegistry.Lastfm.Scrobble
+		// TODO: 更新副标题
+		return NewLastfmRes(m.baseMenu, "切换上报状态", nil, 2)
+	case 2:
 		m.netease.lastfmUser = &storage.LastfmUser{}
 		m.netease.lastfmUser.Clear()
 		return NewLastfmRes(m.baseMenu, "清除授权", nil, 2)

--- a/internal/ui/netease.go
+++ b/internal/ui/netease.go
@@ -124,7 +124,7 @@ func (n *Netease) InitHook(_ *model.App) {
 			var snapshot storage.PlayerSnapshot
 			if err = json.Unmarshal(jsonStr, &snapshot); err == nil {
 				p := n.player
-                p.songManager.init(snapshot.CurSongIndex, snapshot.Playlist)
+				p.songManager.init(snapshot.CurSongIndex, snapshot.Playlist)
 				p.playlistUpdateAt = snapshot.PlaylistUpdateAt
 				p.playingMenuKey = "from_local_db" // 启动后，重置菜单Key，避免很多问题
 			}

--- a/internal/ui/player.go
+++ b/internal/ui/player.go
@@ -867,7 +867,9 @@ func (p *Player) buildNeteaseReportService() *service.ReportService {
 
 func (p *Player) reportStart() {
 	p.buildNeteaseReportService().Playstart()
-	lastfm.Report(p.netease.lastfm, lastfm.ReportPhaseStart, p.CurSong(), p.PassedTime())
+	if configs.ConfigRegistry.Lastfm.Scrobble {
+		lastfm.Report(p.netease.lastfm, lastfm.ReportPhaseStart, p.CurSong(), p.PassedTime())
+	}
 }
 
 func (p *Player) reportEnd() {
@@ -889,8 +891,10 @@ func (p *Player) reportEnd() {
 	}
 	svc.Playend()
 
-	// 播放过一半, 上报lastfm
-	if p.PassedTime().Seconds() >= p.CurSong().Duration.Seconds()/2 {
-		lastfm.Report(p.netease.lastfm, lastfm.ReportPhaseComplete, p.CurSong(), p.PassedTime())
+	if configs.ConfigRegistry.Lastfm.Scrobble {
+		// 播放过一半, 上报lastfm
+		if p.PassedTime().Seconds() >= p.CurSong().Duration.Seconds()/2 {
+			lastfm.Report(p.netease.lastfm, lastfm.ReportPhaseComplete, p.CurSong(), p.PassedTime())
+		}
 	}
 }

--- a/utils/filex/embed/go-musicfox.ini
+++ b/utils/filex/embed/go-musicfox.ini
@@ -129,3 +129,5 @@ qqCookieFile=
 key=
 # Shared Secret
 secret=
+# 是否上报，bool
+scrobble=true


### PR DESCRIPTION
用于临时切换 last.fm 上报状态

