### PR TITLE
Bugfix: beep seek

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ $ musicfox
   * 参照[手动编译](#手动编译)一节自行编译。
 
   > 这里之所以使用 FLAC8，主要是为了兼容大部分系统，因为FLAC是向前兼容的（也就是说 `≥ 8` 的FLAC都可以使用）
+- wsl 环境下使用 beep 须安装 `libasound2-plugins`，见 [issues](https://github.com/microsoft/wslg/issues/864)
 
 </details>
 <details>

--- a/internal/player/beep_player.go
+++ b/internal/player/beep_player.go
@@ -289,7 +289,7 @@ func (p *beepPlayer) Seek(duration time.Duration) {
 	}
 	if p.state == types.Playing || p.state == types.Paused {
 		speaker.Lock()
-		newPos := sampleRate.N(duration)
+		newPos := p.curFormat.SampleRate.N(duration)
 
 		if newPos < 0 {
 			newPos = 0

--- a/internal/player/beep_player.go
+++ b/internal/player/beep_player.go
@@ -151,7 +151,6 @@ func (p *beepPlayer) listen() {
 						}
 					}()
 					_, _ = iox.CopyClose(ctx, cacheWFile, read)
-					p.cacheDownloaded = true
 					p.l.Lock()
 					defer p.l.Unlock()
 					if p.curStreamer == nil {
@@ -179,6 +178,7 @@ func (p *beepPlayer) listen() {
 						_ = p.curStreamer.Seek(pos)
 						p.ctrl.Streamer = beep.Seq(p.resampleStreamer(p.curFormat.SampleRate), beep.Callback(doneHandle))
 					}
+					p.cacheDownloaded = true
 				}(ctx, p.cacheWriter, reader)
 
 				N := 512
@@ -277,7 +277,7 @@ func (p *beepPlayer) TimeChan() <-chan time.Duration {
 }
 
 func (p *beepPlayer) Seek(duration time.Duration) {
-	if duration < 0 {
+	if duration < 0 || !p.cacheDownloaded {
 		return
 	}
 	// FIXME: 暂时仅对MP3格式提供跳转功能

--- a/internal/player/beep_player.go
+++ b/internal/player/beep_player.go
@@ -192,6 +192,7 @@ func (p *beepPlayer) listen() {
 				}
 			} else {
 				// 单曲循环以及歌单只有一首歌时不再请求网络
+				p.cacheDownloaded = true
 				if p.cacheReader, err = os.OpenFile(cacheFile, os.O_RDONLY, 0666); err != nil {
 					panic(err)
 				}


### PR DESCRIPTION
修复：
1. 复用缓存文件未正确更新状态导致的播放结束后等待
2. 避免在缓存完成前执行 Seek，避免播放进度在跳转后不一致
3. 使用真实码率计算 Seek 位置，避免播放进度在跳转后不一致
4. 添加 wsl 环境下的 beep 不可用的说明及解决方式