### PR TITLE
feat: 添加可自定义的颜色配置选项

### DIFF
--- a/cmd/musicfox.go
+++ b/cmd/musicfox.go
@@ -35,6 +35,9 @@ func musicfox() {
 	filex.LoadIniConfig()
 
 	util.PrimaryColor = configs.ConfigRegistry.Main.PrimaryColor
+	util.MenuTitleColor = configs.ConfigRegistry.Main.MenuTitleColor
+	util.ProgressColorExcludeRanges = configs.ConfigRegistry.Main.ProgressColorExcludeRanges
+	util.ProgressColorSaturation = configs.ConfigRegistry.Main.ProgressColorSaturation
 	var (
 		logo         = util.GetAlphaAscii(app.Name)
 		randomColor  = util.GetPrimaryColor()

--- a/internal/configs/main.go
+++ b/internal/configs/main.go
@@ -9,6 +9,9 @@ type MainOptions struct {
 	LoadingText            string                   // 主页面加载中提示
 	PlayerSongLevel        service.SongQualityLevel // 歌曲音质级别
 	PrimaryColor           string                   // 主题色
+	MenuTitleColor         string                   // 菜单标题颜色
+	ProgressColorExcludeRanges string               // 进度条颜色排除区间
+	ProgressColorSaturation string                  // 进度条颜色饱和度范围
 	ShowLyric              bool                     // 显示歌词
 	LyricOffset            int                      // 偏移:ms
 	ShowLyricTrans         bool                     // 显示歌词翻译

--- a/internal/configs/registry.go
+++ b/internal/configs/registry.go
@@ -74,6 +74,9 @@ func NewRegistryWithDefault() *Registry {
 			LoadingText:      types.MainLoadingText,
 			PlayerSongLevel:  service.Higher,
 			PrimaryColor:     types.AppPrimaryColor,
+			MenuTitleColor:   "",  // 空字符串表示使用PrimaryColor
+			ProgressColorExcludeRanges: "45-210",
+			ProgressColorSaturation: "50-80,40-80",
 			ShowLyric:        true,
 			ShowLyricTrans:   true,
 			ShowNotify:       true,
@@ -159,6 +162,22 @@ func NewRegistryFromIniFile(filepath string) *Registry {
 	} else {
 		registry.Main.PrimaryColor = types.AppPrimaryColor
 	}
+	
+	// 菜单标题颜色，默认使用主题色
+	menuTitleColor := ini.String("main.menuTitleColor", "")
+	if menuTitleColor != "" {
+		registry.Main.MenuTitleColor = menuTitleColor
+	} else {
+		registry.Main.MenuTitleColor = registry.Main.PrimaryColor
+	}
+	
+	// 进度条颜色排除区间
+	progressColorExcludeRanges := ini.String("main.progressColorExcludeRanges", "45-210")
+	registry.Main.ProgressColorExcludeRanges = progressColorExcludeRanges
+	
+	// 进度条颜色饱和度范围
+	progressColorSaturation := ini.String("main.progressColorSaturation", "50-80,40-80")
+	registry.Main.ProgressColorSaturation = progressColorSaturation
 	registry.Main.ShowLyric = ini.Bool("main.showLyric", true)
 	registry.Main.LyricOffset = ini.Int("main.lyricOffset", 0)
 	registry.Main.ShowLyricTrans = ini.Bool("main.showLyricTrans", true)

--- a/utils/filex/embed/go-musicfox.ini
+++ b/utils/filex/embed/go-musicfox.ini
@@ -38,7 +38,15 @@ songLevel=higher
 # 随机
 # primaryColor=random
 # 经典网易云音乐红
-primaryColor="#ea403f"
+primaryColor="#f90022"
+# 菜单标题颜色（默认使用主题色primaryColor）
+# menuTitleColor="#f90022"
+# 进度条颜色排除区间，避免生成指定色相范围的颜色，格式：start1-end1,start2-end2
+# 默认排除45-210度（黄绿色、绿色和青色区域），色相范围0-360度
+progressColorExcludeRanges="45-210"
+# 进度条颜色饱和度范围，格式：startMin-startMax,endMin-endMax（范围0-100）
+# 分别控制起始色和结束色的饱和度范围，默认起始色50-80%，结束色40-80%
+progressColorSaturation="50-80,40-80"
 # windows,linux下的默认通知图标
 notifyIcon="logo.png"
 # windows,linux下是否使用歌曲专辑封面作为通知图标（如为否则使用默认通知图标）

--- a/vendor/github.com/anhoder/foxful-cli/model/main.go
+++ b/vendor/github.com/anhoder/foxful-cli/model/main.go
@@ -358,7 +358,7 @@ func (m *Main) MenuTitleView(a *App, top *int, menuTitle *MenuItem) string {
 			menuTitleBuilder.WriteString(strings.Repeat(" ", m.menuTitleStartColumn))
 		}
 	}
-	menuTitleBuilder.WriteString(util.SetFgStyle(title, termenv.ANSIBrightGreen))
+	menuTitleBuilder.WriteString(util.SetFgStyle(title, util.GetMenuTitleColor()))
 
 	if top != nil {
 		*top = m.menuTitleStartRow

--- a/vendor/github.com/anhoder/foxful-cli/util/ui.go
+++ b/vendor/github.com/anhoder/foxful-cli/util/ui.go
@@ -28,6 +28,142 @@ func GetPrimaryColor() termenv.Color {
 	return _primaryColor
 }
 
+var MenuTitleColor string = "" // 菜单标题颜色配置
+var ProgressColorExcludeRanges string = "45-210" // 进度条颜色排除区间
+var ProgressColorSaturation string = "50-80,40-80" // 进度条颜色饱和度范围
+
+// GetMenuTitleColor 获取菜单标题颜色
+func GetMenuTitleColor() termenv.Color {
+	if MenuTitleColor != "" && MenuTitleColor != PrimaryColor {
+		return TermProfile.Color(MenuTitleColor)
+	}
+	return GetPrimaryColor()
+}
+
+// parseExcludeRanges 解析排除区间字符串，返回排除的色相范围
+func parseExcludeRanges(rangeStr string) [][]float64 {
+	if rangeStr == "" {
+		return [][]float64{{45, 210}} // 默认排除绿色和青色
+	}
+	
+	var excludeRanges [][]float64
+	parts := strings.Split(rangeStr, ",")
+	
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		
+		rangeParts := strings.Split(part, "-")
+		if len(rangeParts) == 2 {
+			start, err1 := strconv.ParseFloat(strings.TrimSpace(rangeParts[0]), 64)
+			end, err2 := strconv.ParseFloat(strings.TrimSpace(rangeParts[1]), 64)
+			
+			if err1 == nil && err2 == nil && start >= 0 && end <= 360 && start < end {
+				excludeRanges = append(excludeRanges, []float64{start, end})
+			}
+		}
+	}
+	
+	if len(excludeRanges) == 0 {
+		return [][]float64{{45, 210}} // 默认排除绿色和青色
+	}
+	
+	return excludeRanges
+}
+
+// generateSafeColorRanges 根据排除区间生成安全的色相范围
+func generateSafeColorRanges() [][]float64 {
+	excludeRanges := parseExcludeRanges(ProgressColorExcludeRanges)
+	
+	// 将排除区间按起始位置排序
+	for i := 0; i < len(excludeRanges)-1; i++ {
+		for j := i + 1; j < len(excludeRanges); j++ {
+			if excludeRanges[i][0] > excludeRanges[j][0] {
+				excludeRanges[i], excludeRanges[j] = excludeRanges[j], excludeRanges[i]
+			}
+		}
+	}
+	
+	var safeRanges [][]float64
+	lastEnd := 0.0
+	
+	for _, exclude := range excludeRanges {
+		start, end := exclude[0], exclude[1]
+		
+		// 如果当前排除区间之前有安全区间，添加它
+		if start > lastEnd {
+			safeRanges = append(safeRanges, []float64{lastEnd, start})
+		}
+		lastEnd = end
+	}
+	
+	// 添加最后一个安全区间（如果存在）
+	if lastEnd < 360 {
+		safeRanges = append(safeRanges, []float64{lastEnd, 360})
+	}
+	
+	// 如果没有安全区间，使用默认的安全区间
+	if len(safeRanges) == 0 {
+		safeRanges = [][]float64{
+			{0, 50},     // 红色到橙色
+			{200, 240},  // 蓝色
+			{240, 280},  // 蓝紫色
+			{280, 360},  // 紫色到品红
+		}
+	}
+	
+	return safeRanges
+}
+
+// parseSaturationRanges 解析饱和度范围字符串，返回起始色和结束色的饱和度范围
+func parseSaturationRanges(saturationStr string) (startMin, startMax, endMin, endMax float64) {
+	// 默认值
+	startMin, startMax, endMin, endMax = 0.5, 0.8, 0.4, 0.8
+	
+	if saturationStr == "" {
+		return
+	}
+	
+	parts := strings.Split(saturationStr, ",")
+	if len(parts) != 2 {
+		return
+	}
+	
+	// 解析起始色饱和度范围
+	startParts := strings.Split(strings.TrimSpace(parts[0]), "-")
+	if len(startParts) == 2 {
+		if min, err := strconv.ParseFloat(strings.TrimSpace(startParts[0]), 64); err == nil && min >= 0 && min <= 100 {
+			startMin = min / 100.0
+		}
+		if max, err := strconv.ParseFloat(strings.TrimSpace(startParts[1]), 64); err == nil && max >= 0 && max <= 100 {
+			startMax = max / 100.0
+		}
+	}
+	
+	// 解析结束色饱和度范围
+	endParts := strings.Split(strings.TrimSpace(parts[1]), "-")
+	if len(endParts) == 2 {
+		if min, err := strconv.ParseFloat(strings.TrimSpace(endParts[0]), 64); err == nil && min >= 0 && min <= 100 {
+			endMin = min / 100.0
+		}
+		if max, err := strconv.ParseFloat(strings.TrimSpace(endParts[1]), 64); err == nil && max >= 0 && max <= 100 {
+			endMax = max / 100.0
+		}
+	}
+	
+	// 确保最小值不大于最大值
+	if startMin > startMax {
+		startMin, startMax = startMax, startMin
+	}
+	if endMin > endMax {
+		endMin, endMax = endMax, endMin
+	}
+	
+	return
+}
+
 func GetPrimaryColorString() string {
 	if _primaryColorStr != "" {
 		return _primaryColorStr
@@ -52,26 +188,120 @@ func initPrimaryColor() {
 // GetRandomRgbColor get random rgb color
 func GetRandomRgbColor(isRange bool) (string, string) {
 	rand.New(rand.NewSource(time.Now().UnixNano()))
-	r := 255 - rand.Intn(100)
-	rand.New(rand.NewSource(time.Now().UnixNano() / 2))
-	g := 255 - rand.Intn(100)
-	rand.New(rand.NewSource(time.Now().UnixNano() / 3))
-	b := 255 - rand.Intn(100)
-
-	startColor := fmt.Sprintf("#%x%x%x", r, g, b)
+	
+	// 使用HSV色彩空间，根据配置生成安全的色相范围
+	ranges := generateSafeColorRanges()
+	
+	// 随机选择一个安全区间
+	selectedRange := ranges[rand.Intn(len(ranges))]
+	hue := selectedRange[0] + rand.Float64()*(selectedRange[1]-selectedRange[0])
+	
+	// 解析饱和度配置
+	startMin, startMax, endMin, endMax := parseSaturationRanges(ProgressColorSaturation)
+	
+	saturation := startMin + rand.Float64() * (startMax - startMin)  // 使用配置的饱和度范围
+	value := 0.7 + rand.Float64() * 0.2       // 70-90% 亮度
+	
+	r, g, b := hsvToRgb(hue, saturation, value)
+	startColor := fmt.Sprintf("#%02x%02x%02x", r, g, b)
+	
 	if !isRange {
 		return startColor, ""
 	}
 
+	// 为结束颜色生成另一个安全色相
 	rand.New(rand.NewSource(time.Now().UnixNano() / 5))
-	rEnd := 50 + rand.Intn(100)
-	rand.New(rand.NewSource(time.Now().UnixNano() / 7))
-	gEnd := 50 + rand.Intn(100)
-	rand.New(rand.NewSource(time.Now().UnixNano() / 11))
-	bEnd := 50 + rand.Intn(100)
-	endColor := fmt.Sprintf("#%x%x%x", rEnd, gEnd, bEnd)
+	var hueEnd float64
+	
+	// 50%概率在同一区间内生成相近色，50%概率跳到另一个安全区间
+	if rand.Float64() < 0.5 {
+		// 在同一区间内生成相近色
+		rangeWidth := selectedRange[1] - selectedRange[0]
+		maxOffset := rangeWidth * 0.6  // 最多偏移区间宽度的60%
+		offset := (rand.Float64() - 0.5) * maxOffset
+		hueEnd = hue + offset
+		
+		// 确保不超出区间
+		if hueEnd < selectedRange[0] {
+			hueEnd = selectedRange[0]
+		} else if hueEnd > selectedRange[1] {
+			hueEnd = selectedRange[1]
+		}
+	} else {
+		// 跳到另一个安全区间，实现更丰富的色彩组合
+		otherRanges := make([][]float64, 0)
+		for _, r := range ranges {
+			if r[0] != selectedRange[0] || r[1] != selectedRange[1] {  // 排除当前区间（精确比较）
+				otherRanges = append(otherRanges, r)
+			}
+		}
+		
+		if len(otherRanges) > 0 {
+			endRange := otherRanges[rand.Intn(len(otherRanges))]
+			hueEnd = endRange[0] + rand.Float64()*(endRange[1]-endRange[0])
+		} else {
+			// 如果没有其他区间，在当前区间内生成
+			rangeWidth := selectedRange[1] - selectedRange[0]
+			maxOffset := rangeWidth * 0.6
+			offset := (rand.Float64() - 0.5) * maxOffset
+			hueEnd = hue + offset
+			
+			if hueEnd < selectedRange[0] {
+				hueEnd = selectedRange[0]
+			} else if hueEnd > selectedRange[1] {
+				hueEnd = selectedRange[1]
+			}
+		}
+	}
+	
+	saturationEnd := endMin + rand.Float64() * (endMax - endMin)  // 使用配置的结束色饱和度范围
+	valueEnd := 0.6 + rand.Float64() * 0.2       // 60-80% 亮度
+	
+	rEnd, gEnd, bEnd := hsvToRgb(hueEnd, saturationEnd, valueEnd)
+	endColor := fmt.Sprintf("#%02x%02x%02x", rEnd, gEnd, bEnd)
 
 	return startColor, endColor
+}
+
+// hsvToRgb converts HSV to RGB values
+func hsvToRgb(h, s, v float64) (r, g, b int) {
+	c := v * s
+	x := c * (1 - abs(mod(h/60, 2) - 1))
+	m := v - c
+	
+	var r1, g1, b1 float64
+	
+	switch {
+	case h < 60:
+		r1, g1, b1 = c, x, 0
+	case h < 120:
+		r1, g1, b1 = x, c, 0
+	case h < 180:
+		r1, g1, b1 = 0, c, x
+	case h < 240:
+		r1, g1, b1 = 0, x, c
+	case h < 300:
+		r1, g1, b1 = x, 0, c
+	default:
+		r1, g1, b1 = c, 0, x
+	}
+	
+	r = int((r1 + m) * 255)
+	g = int((g1 + m) * 255)
+	b = int((b1 + m) * 255)
+	
+	return
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func mod(x, y float64) float64 {
+	return x - y*float64(int(x/y))
 }
 
 // SetFgStyle Return a function that will colorize the foreground of a given string.
@@ -94,14 +324,43 @@ func GetPrimaryFontStyle() lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(GetPrimaryColorString()))
 }
 
-// MakeRamp Generate a blend of colors.
-func MakeRamp(colorA, colorB string, steps float64) (s []string) {
+// MakeRamp Generate a blend of colors using HSV to avoid green hues.
+func MakeRamp(colorA, colorB string, steps float64) (result []string) {
 	cA, _ := colorful.Hex(colorA)
 	cB, _ := colorful.Hex(colorB)
-
+	
+	// 转换为HSV
+	hA, sA, vA := cA.Hsv()
+	hB, sB, vB := cB.Hsv()
+	
+	// 确保色相以最短路径插值，且避开绿色区域
+	if abs(hB - hA) > 180 {
+		if hA < hB {
+			hA += 360
+		} else {
+			hB += 360
+		}
+	}
+	
 	for i := 0.0; i < steps; i++ {
-		c := cA.BlendLuv(cB, i/steps)
-		s = append(s, colorToHex(c))
+		t := i / steps
+		
+		// 在HSV空间中插值
+		h := hA + (hB - hA) * t
+		saturation := sA + (sB - sA) * t
+		value := vA + (vB - vA) * t
+		
+		// 确保色相在0-360范围内
+		for h < 0 {
+			h += 360
+		}
+		for h >= 360 {
+			h -= 360
+		}
+		
+		// 转回RGB
+		c := colorful.Hsv(h, saturation, value)
+		result = append(result, colorToHex(c))
 	}
 	return
 }


### PR DESCRIPTION
- 新增菜单标题颜色配置 (menuTitleColor)
- 新增进度条颜色排除区间配置 (progressColorExcludeRanges)
- 新增进度条颜色饱和度范围配置 (progressColorSaturation)
- 修复菜单标题硬编码为绿色的问题，现在使用主题色
- 改进进度条颜色生成算法，使用HSV色彩空间避免绿色
- 支持用户通过配置文件自定义颜色偏好
- 默认排除45-210度色相范围，避免黄绿、绿色和青色
- 将默认主题色更新为标准网易云音乐红 (#f90022)

配置示例：
menuTitleColor="#0066cc"
progressColorExcludeRanges="80-160"
progressColorSaturation="30-60,20-50"