### PR TITLE
fix:默认禁用cookie以避免未指定cookie时启动报错

### DIFF
--- a/utils/filex/embed/go-musicfox.ini
+++ b/utils/filex/embed/go-musicfox.ini
@@ -76,7 +76,7 @@ dynamicMenuRows=false
 # 界面所有内容居中（实验性功能，未来版本中可能会大幅改动）
 centerEverything=false
 # 网易云登录cookie
-neteaseCookie=""
+#neteaseCookie=""
 
 [global_hotkey]
 # 全局快捷键


### PR DESCRIPTION
避免第一次启动因为未在配置文件指定cookie导致启动失败