### PR TITLE
feat(last.fm): support scrobble with single-artist

### DIFF
--- a/internal/configs/lastfm.go
+++ b/internal/configs/lastfm.go
@@ -1,8 +1,9 @@
 package configs
 
 type LastfmOptions struct {
-	Enable        bool   // 是否启用
-	Key           string // API Key
-	Secret        string // API Shared Secret
-	ScrobblePoint int    // 上报百分比
+	Enable          bool   // 是否启用
+	Key             string // API Key
+	Secret          string // API Shared Secret
+	ScrobblePoint   int    // 上报百分比
+	OnlyFirstArtist bool   // 只上报一位艺术家
 }

--- a/internal/configs/registry.go
+++ b/internal/configs/registry.go
@@ -103,10 +103,11 @@ func NewRegistryWithDefault() *Registry {
 			UnlockSoundEffects: true,
 		},
 		Lastfm: LastfmOptions{
-			Key:           "",
-			Secret:        "",
-			Enable:        false,
-			ScrobblePoint: 50,
+			Key:             "",
+			Secret:          "",
+			Enable:          false,
+			ScrobblePoint:   50,
+			OnlyFirstArtist: false,
 		},
 		Keybindings: getDefaultBindingsMap(), // 初始化为默认键绑定
 	}
@@ -235,6 +236,7 @@ func NewRegistryFromIniFile(filepath string) *Registry {
 	registry.Lastfm.Secret = ini.String("lastfm.secret", "")
 	registry.Lastfm.Enable = ini.Bool("lastfm.enable", false)
 	registry.Lastfm.ScrobblePoint = ini.Int("lastfm.scrobblePoint", 50)
+	registry.Lastfm.OnlyFirstArtist = ini.Bool("lastfm.onlyFirstArtist", false)
 
 	userKeybindingsRaw := ini.StringMap("keybindings")
 	registry.Keybindings = keybindings.BuildEffectiveBindings(userKeybindingsRaw, registry.Main.UseDefaultKeyBindings)

--- a/internal/storage/lastfm_scrobble.go
+++ b/internal/storage/lastfm_scrobble.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Scrobble struct {
-	Artist     string        `json:"artist"`
+	Artist     []string      `json:"artist"`
 	Track      string        `json:"track"`
 	Album      string        `json:"album"`
 	Duration   time.Duration `json:"duration"`
@@ -19,7 +19,7 @@ type Scrobble struct {
 
 func NewScrobble(song structs.Song, playedTime time.Duration) *Scrobble {
 	return &Scrobble{
-		Artist:     song.ArtistName(),
+		Artist:     ArtistNames(song.Artists),
 		Track:      song.Name,
 		Album:      song.Album.Name,
 		Timestamp:  time.Now().Unix(),
@@ -64,4 +64,16 @@ func (sl *ScrobbleList) InitFromStorage() {
 	if jsonStr, err := t.GetByKVModel(sl); err == nil {
 		_ = json.Unmarshal(jsonStr, &sl.Scrobbles)
 	}
+}
+
+func ArtistNames(artists []structs.Artist) []string {
+	names := make([]string, len(artists))
+	for i, artist := range artists {
+		names[i] = artist.Name
+	}
+	return names
+}
+
+func (s *Scrobble) FilterArtist() {
+	s.Artist = s.Artist[:1]
 }

--- a/utils/filex/embed/go-musicfox.ini
+++ b/utils/filex/embed/go-musicfox.ini
@@ -146,6 +146,8 @@ enable=false
 # 或播放至少多少才请求上报？（百分比，至少 50%，请填写整数值）
 # 由于实际播放时长的计算存在误差，故播放时长比实际时长差值在 3s 内即认为 100%
 scrobblePoint=50
+# 只上报第一位艺术家
+onlyFirstArtist=false
 
 # 自定义快捷键
 # 格式为：operate = key1, key2...


### PR DESCRIPTION
提供设置lastfm只上报第一位艺术家，这是一个解决lastfm上艺术家匹配的解决方式之一（