### PR TITLE
fix: parse bad cookies

### DIFF
--- a/internal/ui/netease.go
+++ b/internal/ui/netease.go
@@ -104,12 +104,17 @@ func (n *Netease) InitHook(_ *model.App) {
 
 		if n.user == nil && config.Main.NeteaseCookie != "" {
 			// 使用cookie登录
-			cookieJar.SetCookies(
-				errorx.Must1(url.Parse("https://music.163.com")),
-				errorx.Must1(http.ParseCookie(config.Main.NeteaseCookie)),
-			)
-			if err := n.LoginCallback(); err != nil {
-				slog.Warn("使用cookie登录失败", slogx.Error(err))
+			cookies, err := http.ParseCookie(config.Main.NeteaseCookie)
+			if err != nil {
+				slog.Error("网易云 cookies 格式错误", "error", err)
+			} else {
+				cookieJar.SetCookies(
+					errorx.Must1(url.Parse("https://music.163.com")),
+					cookies,
+				)
+				if err := n.LoginCallback(); err != nil {
+					slog.Warn("使用cookie登录失败", slogx.Error(err))
+				}
 			}
 		}
 


### PR DESCRIPTION
避免由于错误 cookies 导致 panic 致使终端不可用