### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: write
+  packages: write
 name: release
 
 defaults:


### PR DESCRIPTION
Potential fix for [https://github.com/go-musicfox/go-musicfox/security/code-scanning/1](https://github.com/go-musicfox/go-musicfox/security/code-scanning/1)

To fix this problem, add an explicit `permissions` block to the workflow file at the root level, so it applies to all jobs unless overridden. Analyze the workflow's steps for required permissions:

- The workflow pushes code (`ad-m/github-push-action@master`), so it needs `contents: write`.
- It uploads artifacts (actions/upload-artifact@v4), which does not require increased permissions (defaults to read).
- It logs in to the container registry with the provided token, generally requiring `packages: write`.
- Other steps (checkout, setup, etc.) can operate with just `contents: read`.

To follow the principle of least privilege, we recommend starting with the minimal required permissions, increasing only what's necessary (contents: write, packages: write). Add this block after the `name:` field (line 1), before the jobs section. No additional imports or definitions are needed, just the new YAML keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
