### PR TITLE
refactor(config): group storage-related configurations

### DIFF
--- a/internal/configs/registry.go
+++ b/internal/configs/registry.go
@@ -28,6 +28,7 @@ type Registry struct {
 	// Keybindings 存储最终生效的操作ID -> 按键列表映射
 	Keybindings map[keybindings.OperateType][]string
 	Share       map[string]string
+	Storge      StorgeOptions
 }
 
 func (r *Registry) FillToModelOpts(opts *model.Options) {
@@ -86,13 +87,18 @@ func NewRegistryWithDefault() *Registry {
 			PProfPort:             types.MainPProfPort,
 			AltScreen:             true,
 			EnableMouseEvent:      true,
-			DownloadDir:           "",
-			CacheLimit:            0,
 			DynamicMenuRows:       false,
 			UseDefaultKeyBindings: true,
 			CenterEverything:      false,
 			NeteaseCookie:         "",
 			Debug:                 false,
+		},
+		Storge: StorgeOptions{
+			DownloadDir:         "",
+			DownloadFileNameTpl: "{{.SongName}}-{{.SongArtists}}.{{.FileExt}}",
+			CacheLimit:          0,
+			DownloadLyricDir:    "",
+			CacheDir:            "",
 		},
 		Player: PlayerOptions{
 			Engine:         types.BeepPlayer,
@@ -186,17 +192,23 @@ func NewRegistryFromIniFile(filepath string) *Registry {
 	registry.Main.AltScreen = ini.Bool("main.altScreen", true)
 	registry.Main.EnableMouseEvent = ini.Bool("main.enableMouseEvent", true)
 	registry.Main.DualColumn = ini.Bool("main.doubleColumn", true)
-	registry.Main.DownloadDir = ini.String("main.downloadDir", "")
-	registry.Main.DownloadLyricDir = ini.String("main.downloadLyricDir", "")
-	registry.Main.DownloadFileNameTpl = ini.String("main.downloadFileNameTpl", "")
 	registry.Main.ShowAllSongsOfPlaylist = ini.Bool("main.showAllSongsOfPlaylist", false)
-	registry.Main.CacheDir = ini.String("main.cacheDir", "")
-	registry.Main.CacheLimit = ini.Int64("main.cacheLimit", 0)
 	registry.Main.DynamicMenuRows = ini.Bool("main.dynamicMenuRows", false)
 	registry.Main.UseDefaultKeyBindings = ini.Bool("main.useDefaultKeyBindings", true)
 	registry.Main.CenterEverything = ini.Bool("main.centerEverything", false)
 	registry.Main.NeteaseCookie = ini.String("main.neteaseCookie", "")
 	registry.Main.Debug = ini.Bool("main.debug", false)
+
+	downloadDir := ini.String("main.downloadDir", "")
+	downloadLyricDir := ini.String("main.downloadLyricDir", "")
+	downloadFileNameTpl := ini.String("main.downloadFileNameTpl", "{{.SongName}}-{{.SongArtists}}.{{.FileExt}}")
+	cacheDir := ini.String("main.cacheDir", "")
+	cacheLimit := ini.Int64("main.cacheLimit", 0)
+	registry.Storge.DownloadDir = ini.String("stroge.downloadDir", downloadDir)
+	registry.Storge.DownloadLyricDir = ini.String("stroge.downloadLyricDir", downloadLyricDir)
+	registry.Storge.DownloadFileNameTpl = ini.String("stroge.downloadFileNameTpl", downloadFileNameTpl)
+	registry.Storge.CacheDir = ini.String("stroge.cacheDir", cacheDir)
+	registry.Storge.CacheLimit = ini.Int64("stroge.cacheLimit", cacheLimit)
 
 	defaultPlayer := types.BeepPlayer
 	switch runtime.GOOS {

--- a/internal/configs/storge.go
+++ b/internal/configs/storge.go
@@ -1,0 +1,10 @@
+package configs
+
+// StorgeOptions 下载、缓存等相关配置
+type StorgeOptions struct {
+	DownloadDir         string // 指定下载目录
+	DownloadFileNameTpl string // 下载文件名模板
+	DownloadLyricDir    string // 指定歌词文件下载目录
+	CacheDir            string // 指定缓存目录
+	CacheLimit          int64  // 缓存大小（以MB为单位），0为不使用缓存，-1为不限制，默认为0
+}

--- a/internal/ui/netease.go
+++ b/internal/ui/netease.go
@@ -60,9 +60,9 @@ func NewNetease(app *model.App) *Netease {
 	n.shareSvc.RegisterTemplates(configs.ConfigRegistry.Share)
 
 	quality := configs.ConfigRegistry.Main.PlayerSongLevel
-	maxSizeMB := configs.ConfigRegistry.Main.CacheLimit
+	maxSizeMB := configs.ConfigRegistry.Storge.CacheLimit
 	nameGen := composer.NewFileNameGenerator()
-	nameGen.RegisterSongTemplate(configs.ConfigRegistry.Main.DownloadFileNameTpl)
+	nameGen.RegisterSongTemplate(configs.ConfigRegistry.Storge.DownloadFileNameTpl)
 	n.trackManager = track.NewManager(
 		track.WithNameGenerator(nameGen),
 		track.WithCacher(track.NewCacher(maxSizeMB)),

--- a/utils/app/app.go
+++ b/utils/app/app.go
@@ -73,7 +73,7 @@ func initPaths() {
 func initPathsWithConfig() {
 	initPathsOnce.Do(func() {
 		initPaths()
-		if userCacheDir := configs.ConfigRegistry.Main.CacheDir; userCacheDir != "" {
+		if userCacheDir := configs.ConfigRegistry.Storge.CacheDir; userCacheDir != "" {
 			if paths.isPortable {
 				paths.cacheDir = filepath.Join(paths.rootDir, userCacheDir)
 			} else {
@@ -82,7 +82,7 @@ func initPathsWithConfig() {
 		}
 		paths.musicCacheDir = filepath.Join(paths.cacheDir, "music_cache")
 
-		if userDownloadDir := configs.ConfigRegistry.Main.DownloadDir; userDownloadDir != "" {
+		if userDownloadDir := configs.ConfigRegistry.Storge.DownloadDir; userDownloadDir != "" {
 			if paths.isPortable {
 				paths.downloadDir = filepath.Join(paths.rootDir, userDownloadDir)
 			} else {
@@ -160,7 +160,7 @@ func DownloadDir() string {
 
 // DownloadLyricDir 歌词下载目录，同 DownloadDir
 func DownloadLyricDir() string {
-	customDir := configs.ConfigRegistry.Main.DownloadLyricDir
+	customDir := configs.ConfigRegistry.Storge.DownloadLyricDir
 	if customDir == "" {
 		return DownloadDir()
 	}

--- a/utils/filex/embed/go-musicfox.ini
+++ b/utils/filex/embed/go-musicfox.ini
@@ -59,22 +59,6 @@ altScreen=true
 enableMouseEvent=true
 # 双列显示，开启务必使用等宽字体
 doubleColumn=true
-# 下载目录
-# 若设置了 MUSICFOX_ROOT 变量，则默认为 ${MUSICFOX_ROOT}/download
-# 若未设置 MUSICFOX_ROOT 变量，则为相应系统的默认下载目录的 go-musicfox 子目录
-# 请使用绝对路径
-downloadDir=
-# 默认值与 downloadDir 一致
-downloadLyricDir=
-# 文件名模板
-downloadFileNameTpl={{.SongName}}-{{.SongArtists}}.{{.FileExt}}
-# 缓存目录
-# 若设置了 MUSICFOX_ROOT 变量，则默认为 ${MUSICFOX_ROOT}/download
-# 若未设置 MUSICFOX_ROOT 变量，则为相应系统的默认缓存目录的 go-musicfox 子目录
-# !!!注意!!! 如果使用mpd,mpd配置中的"music_directory"必须与cacheDir一致
-cacheDir=
-# 缓存大小（以MB为单位），0为不使用缓存，-1为不限制，默认为0
-cacheLimit=0
 # 是否显示歌单下所有歌曲，默认不开启，仅获取歌单前1000首，开启后可能会占用更多内存（大量歌曲数据）和带宽（会同时发送多个请求获取歌单下歌曲数据）
 showAllSongsOfPlaylist=false
 # 动态显示menu行数
@@ -87,6 +71,27 @@ centerEverything=false
 neteaseCookie=
 # 是否开启 debug 模式
 debug=false
+
+# 下载、缓存相关配置
+[storage]
+# 下载目录
+# 若设置了 MUSICFOX_ROOT 变量，则默认为 ${MUSICFOX_ROOT}/download
+# 若未设置 MUSICFOX_ROOT 变量，则为相应系统的默认下载目录的 go-musicfox 子目录
+# 请使用绝对路径
+downloadDir=
+# 默认值与 downloadDir 一致
+downloadLyricDir=
+# 文件名模板
+# 可用字段参考 #自定义分享模板 中的 song 部分，FileExt 为自适应的后缀名
+# downloadFileNameTpl={{.SongName}}-{{.SongArtists}}.{{.FileExt}}
+
+# 缓存目录
+# 若设置了 MUSICFOX_ROOT 变量，则默认为 ${MUSICFOX_ROOT}/cache
+# 若未设置 MUSICFOX_ROOT 变量，则为相应系统的默认缓存目录的 go-musicfox 子目录
+# !!!注意!!! 如果使用mpd,mpd配置中的"music_directory"必须与cacheDir一致
+cacheDir=
+# 缓存大小（以MB为单位），0为不使用缓存，-1为不限制，默认为0
+cacheLimit=0
 
 [global_hotkey]
 # 全局快捷键


### PR DESCRIPTION
将下载和缓存设置独立出 [main] ，新位置为 '[storage]' ，兼容旧配置