### PR TITLE
fix(beep): 修复快速切歌时因并发竞争导致的 panic 和死锁

### DIFF
--- a/internal/player/beep_player.go
+++ b/internal/player/beep_player.go
@@ -145,11 +145,6 @@ func (p *beepPlayer) listen() {
 
 				// 边下载边播放
 				go func(ctx context.Context, cacheWFile *os.File, read io.ReadCloser) {
-					defer func() {
-						if errorx.Recover(true) {
-							p.Stop()
-						}
-					}()
 					_, _ = iox.CopyClose(ctx, cacheWFile, read)
 					p.l.Lock()
 					defer p.l.Unlock()
@@ -454,12 +449,9 @@ func (p *beepPlayer) reset() {
 }
 
 func (p *beepPlayer) streamer(samples [][2]float64) (n int, ok bool) {
-	defer func() {
-		if err := recover(); err != nil {
-			slog.Error("streamer panic", slogx.Error(err))
-			p.Stop()
-		}
-	}()
+	p.l.Lock()
+	defer p.l.Unlock()
+
 	pos := p.curStreamer.Position()
 	n, ok = p.curStreamer.Stream(samples)
 	err := p.curStreamer.Err()


### PR DESCRIPTION
在快速、连续地切换歌曲时，播放器有一定几率会发生 `panic` (空指针引用)。

此前代码中尝试通过 `recover` 捕获此 `panic`，但这不仅没有解决根本问题，反而引入了新的死锁问题，导致程序在 `recover` 后卡死，无法响应任何操作。

此次使用互斥锁保证安全。

另一个解决方式是将`recover` 块中的 `p.Stop()` 改为 `p.stopNoLock()` 避免在恢复后死锁，但这种方法可能导致内部状态混乱。