### PR TITLE
ci: add workflow to automate vendor sync

### DIFF
--- a/.github/workflows/vendor-sync.yml
+++ b/.github/workflows/vendor-sync.yml
@@ -1,0 +1,62 @@
+name: Sync Go Vendor
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/vendor-sync.yml'
+
+jobs:
+  vendor-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          persist-credentials: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "^1.22.0"
+
+      - name: Run go mod vendor
+        run: |
+          go mod tidy
+          go mod vendor
+
+      - name: Stage files and check for changes
+        id: check_changes
+        run: |
+          git add go.mod go.sum vendor/
+          
+          if ! git diff --cached --quiet; then
+            echo "Changes detected in vendor directory or go modules."
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "No changes detected."
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request for Vendor Updates
+        if: steps.check_changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(vendor): sync go vendor directory"
+          committer: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          
+          title: "Chore: Automate vendor sync"
+          body: |
+            An automatic workflow has detected changes in `go.mod` or `go.sum` and updated the vendor directory accordingly.
+            
+            This PR is automatically generated. Please review and merge.
+          
+          branch: "bot/vendor-sync"
+          
+          labels: |
+            dependencies


### PR DESCRIPTION
添加 ci 用于管理 vendor 变更，vendor 内的变更将归属于 github-actions[bot]