### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vendor-sync.yml
+++ b/.github/workflows/vendor-sync.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   vendor-sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/go-musicfox/go-musicfox/security/code-scanning/2](https://github.com/go-musicfox/go-musicfox/security/code-scanning/2)

To fix the issue, we should add a `permissions` block to explicitly set the minimal permissions required by the workflow/job. The `checkout` and Go mod steps only require read access to repo contents, but the pull request creation step (`peter-evans/create-pull-request`) needs `pull-requests: write` and possibly `contents: write` if changes are being pushed. For this case, review of the action documentation ([link](https://github.com/peter-evans/create-pull-request#permissions)) suggests that both `contents: write` and `pull-requests: write` are required.

Best practice is to set the `permissions` block under the job (`vendor-sync`) to just these required values:

```yaml
permissions:
  contents: write
  pull-requests: write
```

To implement:
- In `.github/workflows/vendor-sync.yml`, add the above snippet as a key under the job `vendor-sync` (after `runs-on`).
- No imports or code changes needed outside of YAML edits.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
