### PR TITLE
细粒度的音量控制

### DIFF
--- a/internal/configs/player.go
+++ b/internal/configs/player.go
@@ -25,6 +25,9 @@ type PlayerConfig struct {
 	// 显示歌单下所有歌曲
 	ShowAllSongsOfPlaylist bool `koanf:"showAllSongsOfPlaylist"`
 
+	// 鼠标滚轮单次滚动调节的音量值 (取值范围 1-20)
+	MouseVolumeStep int `koanf:"mouseVolumeStep"`
+
 	Beep BeepConfig `koanf:"beep"`
 	Mpd  MpdConfig  `koanf:"mpd"`
 	Mpv  MpvConfig  `koanf:"mpv"`

--- a/internal/player/beep_player.go
+++ b/internal/player/beep_player.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -340,7 +341,10 @@ func (p *beepPlayer) DownVolume() {
 }
 
 func (p *beepPlayer) Volume() int {
-	return int((p.volume.Volume + 5) * 100 / 5) // 转为0~100存储
+	p.l.Lock()
+	defer p.l.Unlock()
+	floatVolume := (p.volume.Volume + 5) * 100 / 5
+	return int(math.Round(floatVolume)) // 转为0~100存储
 }
 
 func (p *beepPlayer) SetVolume(volume int) {

--- a/utils/filex/embed/config.toml
+++ b/utils/filex/embed/config.toml
@@ -131,6 +131,8 @@ songLevel = "higher"
 # 是否获取并显示歌单下的所有歌曲，默认前 1000 首
 # 开启后可能会占用更多内存（大量歌曲数据）和带宽（会同时发送多个请求获取歌单下歌曲数据）
 showAllSongsOfPlaylist = false
+# Ctrl + 鼠标滚轮单次滚动调节的音量值 (取值范围 1-20)
+mouseVolumeStep = 1
 
 # `beep` 引擎专属配置 (跨平台)
 [player.beep]


### PR DESCRIPTION
添加 Ctrl+滚轮 以支持更细粒度的音量控制。单次调节范围（`MouseVolumeStep`）限制在 1-20，太大的数值无意义。

考虑将该配置作为常规设置而取消 `DownVolume` 和 `UpVolume` 方法，或将其改为为受 `MouseVolumeStep` 值控制，从而避免 Ctrl 键的修饰。

close #491 