### PR TITLE
fix(notify): avoid panic when dbus is unavailable

### DIFF
--- a/utils/notify/notification.go
+++ b/utils/notify/notification.go
@@ -152,6 +152,7 @@ func Notify(content NotifyContent) {
 		freedesktop_dbus, err := dbus.ConnectSessionBus()
 		if err != nil {
 			log.Printf("connect dbus failed: %+v", errors.WithStack(err))
+			return
 		}
 		defer freedesktop_dbus.Close()
 		notfiy := freedesktop_dbus.Object("org.freedesktop.Notifications", "/org/freedesktop/Notifications")


### PR DESCRIPTION
dbus 不可用时及时退出避免 panic