### PR TITLE
修复在Linux系统特定条件下自动切换歌曲出现错误或卡住的问题

### DIFF
--- a/internal/player/beep_player.go
+++ b/internal/player/beep_player.go
@@ -59,9 +59,9 @@ func NewBeepPlayer() *beepPlayer {
 	p := &beepPlayer{
 		state: types.Stopped,
 
-		timeChan:  make(chan time.Duration),
-		stateChan: make(chan types.State),
-		musicChan: make(chan URLMusic),
+		timeChan:  make(chan time.Duration, 1),
+		stateChan: make(chan types.State, 10),
+		musicChan: make(chan URLMusic, 1),
 		ctrl: &beep.Ctrl{
 			Paused: false,
 		},
@@ -125,6 +125,7 @@ func (p *beepPlayer) listen() {
 
 			if prevSongId != p.curMusic.Id || !filex.FileOrDirExists(cacheFile) {
 				// FIXME: 先这样处理，暂时没想到更好的办法
+				_ = os.Remove(cacheFile)
 				if p.cacheReader, err = os.OpenFile(cacheFile, os.O_CREATE|os.O_TRUNC|os.O_RDONLY, 0666); err != nil {
 					panic(err)
 				}

--- a/internal/player/mpd_player.go
+++ b/internal/player/mpd_player.go
@@ -106,9 +106,9 @@ func NewMpdPlayer(conf *MpdConfig) *mpdPlayer {
 		conf:      conf,
 		watcher:   watcher,
 		state:     types.Stopped,
-		timeChan:  make(chan time.Duration),
-		stateChan: make(chan types.State),
-		musicChan: make(chan URLMusic),
+		timeChan:  make(chan time.Duration, 1),
+		stateChan: make(chan types.State, 10),
+		musicChan: make(chan URLMusic, 1),
 		close:     make(chan struct{}),
 	}
 

--- a/internal/player/mpv_player.go
+++ b/internal/player/mpv_player.go
@@ -63,8 +63,8 @@ func NewMpvPlayer(conf *MpvConfig) *mpvPlayer {
 		binPath:   binPath, // 保存自定义路径
 		volume:    50,      // 默认音量
 		state:     types.Stopped,
-		timeChan:  make(chan time.Duration),
-		stateChan: make(chan types.State),
+		timeChan:  make(chan time.Duration, 1),
+		stateChan: make(chan types.State, 10),
 		close:     make(chan struct{}),
 	}
 

--- a/internal/player/osx_player_darwin.go
+++ b/internal/player/osx_player_darwin.go
@@ -36,9 +36,9 @@ type osxPlayer struct {
 func NewOsxPlayer() *osxPlayer {
 	p := &osxPlayer{
 		state:     types.Stopped,
-		timeChan:  make(chan time.Duration),
-		stateChan: make(chan types.State),
-		musicChan: make(chan URLMusic),
+		timeChan:  make(chan time.Duration, 1),
+		stateChan: make(chan types.State, 10),
+		musicChan: make(chan URLMusic, 1),
 		close:     make(chan struct{}),
 		volume:    100,
 	}

--- a/internal/player/win_media_player_windows.go
+++ b/internal/player/win_media_player_windows.go
@@ -66,9 +66,9 @@ type winMediaPlayer struct {
 func NewWinMediaPlayer() *winMediaPlayer {
 	p := &winMediaPlayer{
 		state:     types.Stopped,
-		timeChan:  make(chan time.Duration),
-		stateChan: make(chan types.State),
-		musicChan: make(chan URLMusic),
+		timeChan:  make(chan time.Duration, 1),
+		stateChan: make(chan types.State, 10),
+		musicChan: make(chan URLMusic, 1),
 		close:     make(chan struct{}),
 		volume:    100,
 	}

--- a/internal/remote_control/mpris_player_linux.go
+++ b/internal/remote_control/mpris_player_linux.go
@@ -85,7 +85,7 @@ func (p *Player) createStatus(info PlayingInfo) {
 		"Volume":         newProp(volume, p.OnVolume),
 		"Position": {
 			Value:    UsFromDuration(info.PassedDuration),
-			Writable: false,
+			Writable: true,
 			Emit:     prop.EmitFalse,
 			Callback: nil,
 		},

--- a/internal/remote_control/remote_control_linux.go
+++ b/internal/remote_control/remote_control_linux.go
@@ -297,7 +297,7 @@ func (s *RemoteControl) SetPosition(duration time.Duration) {
 	}
 
 	position := UsFromDuration(duration)
-	s.props.SetMust("org.mpris.MediaPlayer2.Player", "Position", dbus.MakeVariant(position))
+	_ = s.props.Set("org.mpris.MediaPlayer2.Player", "Position", dbus.MakeVariant(position))
 
 	if s.dbus != nil {
 		_ = s.dbus.Emit("/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2.Player.Seeked", position)

--- a/internal/ui/player.go
+++ b/internal/ui/player.go
@@ -100,7 +100,7 @@ func NewPlayer(n *Netease, lyricService *lyric.Service) *Player {
 		netease:         n,
 		lyricService:    lyricService,
 		playlistManager: playlist.NewPlaylistManager(),
-		ctrl:            make(chan CtrlSignal),
+		ctrl:            make(chan CtrlSignal, 10),
 		reporter:        reporter.NewService(reporterOptions...),
 	}
 	var ctx context.Context


### PR DESCRIPTION
MPRIS 属性修复：解决了导致程序协程崩溃的 DBus 只读属性写入报错。
Beep 缓存竞争修复：通过在切歌时强制清理旧缓存，解决了可能导致重复播放的问题。
通道死锁优化：为关键的并发通道增加了缓冲区，提升了系统响应的稳定性。