### PR TITLE
feat(player): 添加 DLNA/UPnP 播放引擎支持及改进

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,10 +200,23 @@ type Player interface {
 | 引擎 | 文件 | 平台 | 特点 |
 |------|------|------|------|
 | **Beep** | `beep_player.go` | 跨平台 | 默认，依赖 go-mp3/go-flac |
+| **DLNA** | `dlna_player.go` | 跨平台 | DLNA 设备投送，file:// URL 自动转为内置 HTTP server |
 | **MPV** | `mpv_player.go` | 跨平台 | IPC 控制，音视频分离 |
 | **MPD** | `mpd_player.go` | Linux | 远程 MPD 服务器 |
 | **AVFoundation** | `osx_player_darwin.go` | macOS | 原生系统集成 |
 | **MediaPlayer** | `win_media_player_windows.go` | Windows | WinRT API |
+
+**DLNA 配置**（`internal/configs/player.go`）：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `deviceUrl` | string | DLNA 设备描述 URL |
+| `localIP` | string | 本机局域网 IP（用于内置 HTTP server） |
+
+**DLNA 特性**：
+- 支持 `file://` URL：自动启动内置 HTTP server，提供文件服务
+- 支持 `http://`/`https://` URL：直接透传给 DLNA 设备
+- 切换曲目时自动清理 fileMap，避免内存泄漏
 
 **音频格式支持**（`beep_decoder.go`）：
 - MP3（支持 minimp3 轻量解码器）
@@ -303,6 +316,7 @@ type Player interface {
 |------|------|
 | `internal/player/player.go` | 接口与工厂 |
 | `internal/player/beep_player.go` | Beep 引擎 |
+| `internal/player/dlna_player.go` | DLNA 引擎 |
 | `internal/player/mpv_player.go` | MPV 引擎 |
 | `internal/player/mpd_player.go` | MPD 引擎 |
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-musicfox | **另一个Spotify版 [Spotifox](https://github.com/go-musicfox/spotifox)**
 
-go-musicfox 是用 Go 写的又一款网易云音乐命令行客户端，支持各种音质级别、UnblockNeteaseMusic、Last.fm、MPRIS 和 macOS 交互响应（睡眠暂停、蓝牙耳机连接断开响应和菜单栏控制等）等功能特性。
+go-musicfox 是用 Go 写的又一款网易云音乐命令行客户端，支持各种音质级别、UnblockNeteaseMusic、Last.fm、MPRIS 和 macOS 交互响应（睡眠暂停、蓝牙耳机连接断开响应和菜单栏控制等）等功能特性，以及 DLNA 投送。
 
 > UI 基于 [charmbracelet/bubbletea](https://github.com/charmbracelet/bubbletea) 进行了部分定制
 
@@ -408,6 +408,34 @@ $ musicfox
   自 [#453](https://github.com/go-musicfox/go-musicfox/pull/453) 起，提供了完整的 XDG 支持，部分文件路径变更，见 [XDG 支持说明](./docs/xdg_support.md)
 - 配置文件格式
   自 [#484](https://github.com/go-musicfox/go-musicfox/pull/484) 起，配置文件格式已由 INI 更换为 [TOML](https://toml.io/)
+
+</details>
+<details>
+<summary>
+
+### DLNA 投送
+</summary>
+
+DLNA 引擎允许你将音乐投送到兼容 DLNA 的设备（如智能电视、音响、游戏机等）。
+
+1. **获取设备 URL**
+   - 安装 `gupnp-tools`：`brew install gupnp-tools`（macOS）或 `sudo apt install gupnp-tools`（Linux）
+   - 运行 `gupnp-universal-cp`，扫描并复制设备的描述 URL（形如 `http://192.168.1.100:49152/description.xml`）
+
+2. **配置**
+   在 `config.toml` 中设置：
+   ```toml
+   [player]
+   engine = "dlna"
+
+   [player.dlna]
+   deviceUrl = "http://你的设备IP:端口/description.xml"
+   localIP = "本机局域网IP"  # 例如 192.168.1.50
+   ```
+
+3. **播放**
+   启动应用后，选择歌曲即可自动投送到 DLNA 设备。
+
 
 </details>
 <details>

--- a/internal/configs/player.go
+++ b/internal/configs/player.go
@@ -62,6 +62,6 @@ type MpvConfig struct {
 
 // DlnaConfig `dlna` 引擎专属配置
 type DlnaConfig struct {
-	// 设备描述 URL
-	DeviceUrl string `koanf:"deviceUrl"`
+	DeviceUrl string `toml:"deviceUrl" mapstructure:"deviceUrl"`
+	LocalIP   string `toml:"localIP" mapstructure:"localIP"`
 }

--- a/internal/configs/player.go
+++ b/internal/configs/player.go
@@ -62,6 +62,6 @@ type MpvConfig struct {
 
 // DlnaConfig `dlna` 引擎专属配置
 type DlnaConfig struct {
-	DeviceUrl string `toml:"deviceUrl" mapstructure:"deviceUrl"`
-	LocalIP   string `toml:"localIP" mapstructure:"localIP"`
+	DeviceUrl string `koanf:"deviceUrl"`
+	LocalIP   string `koanf:"localIP"`
 }

--- a/internal/configs/player.go
+++ b/internal/configs/player.go
@@ -31,6 +31,7 @@ type PlayerConfig struct {
 	Beep BeepConfig `koanf:"beep"`
 	Mpd  MpdConfig  `koanf:"mpd"`
 	Mpv  MpvConfig  `koanf:"mpv"`
+	Dlna DlnaConfig `koanf:"dlna"`
 }
 
 // BeepConfig `beep` 引擎专属配置
@@ -57,4 +58,10 @@ type MpdConfig struct {
 type MpvConfig struct {
 	// mpv路径
 	Bin string `koanf:"bin"`
+}
+
+// DlnaConfig `dlna` 引擎专属配置
+type DlnaConfig struct {
+	// 设备描述 URL
+	DeviceUrl string `koanf:"deviceUrl"`
 }

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -577,22 +577,21 @@ func (p *dlnaPlayer) State() types.State { return p.state }
 
 func (p *dlnaPlayer) StateChan() <-chan types.State { return p.stateChan }
 
-func (p *dlnaPlayer) getVolume() (int, error) {
+func (p *dlnaPlayer) renderControlSOAPRequest(action, body string) (*http.Response, []byte, error) {
 	if p.renderingControlURL == "" {
-		return 0, errors.New("RenderingControl service not available")
+		return nil, nil, errors.New("RenderingControl service not available")
 	}
-	body := getVolumeBody
 	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
 	req, err := http.NewRequest("POST", p.renderingControlURL, bytes.NewBufferString(envelope))
 	if err != nil {
-		return 0, err
+		return nil, nil, err
 	}
 	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
-	req.Header.Set("SOAPAction", `"urn:schemas-upnp-org:service:RenderingControl:1#GetVolume"`)
+	req.Header.Set("SOAPAction", fmt.Sprintf(`"urn:schemas-upnp-org:service:RenderingControl:1#%s"`, action))
 
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
-		return 0, err
+		return nil, nil, err
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -601,15 +600,25 @@ func (p *dlnaPlayer) getVolume() (int, error) {
 	}()
 
 	if resp.StatusCode >= 400 {
-		return 0, fmt.Errorf("GetVolume failed: %d", resp.StatusCode)
+		return nil, nil, fmt.Errorf("%s failed: %d", action, resp.StatusCode)
 	}
 
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resp, respBody, nil
+}
+
+func (p *dlnaPlayer) getVolume() (int, error) {
+	_, respBody, err := p.renderControlSOAPRequest("GetVolume", getVolumeBody)
+	if err != nil {
+		return 0, err
+	}
 
 	type volumeResponse struct {
 		CurrentVolume string `xml:"CurrentVolume"`
 	}
-
 	type envelopeResponse struct {
 		Body struct {
 			GetVolumeResponse volumeResponse `xml:"GetVolumeResponse"`
@@ -627,33 +636,9 @@ func (p *dlnaPlayer) getVolume() (int, error) {
 }
 
 func (p *dlnaPlayer) setVolume(volume int) error {
-	if p.renderingControlURL == "" {
-		return errors.New("RenderingControl service not available")
-	}
 	body := fmt.Sprintf(setVolumeBody, volume)
-	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
-	req, err := http.NewRequest("POST", p.renderingControlURL, bytes.NewBufferString(envelope))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
-	req.Header.Set("SOAPAction", `"urn:schemas-upnp-org:service:RenderingControl:1#SetVolume"`)
-
-	resp, err := p.httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			slog.Error("DLNA: failed to close response body", "error", err)
-		}
-	}()
-
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("SetVolume failed: %d", resp.StatusCode)
-	}
-
-	return nil
+	_, _, err := p.renderControlSOAPRequest("SetVolume", body)
+	return err
 }
 
 func (p *dlnaPlayer) Volume() int {

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -85,8 +85,6 @@ type dlnaPlayer struct {
 	curPos   time.Duration
 	timeChan chan time.Duration
 
-	polling bool
-
 	httpServer *http.Server
 	httpPort   int
 	localIP    string
@@ -183,6 +181,9 @@ func (p *dlnaPlayer) initControlUrl() {
 	if p.renderingControlUrl == "" {
 		slog.Error("DLNA: RenderingControl service not found")
 	}
+
+	// 初始化完成後啟動輪詢，保持連接活躍
+	go p.pollPositionInfo()
 }
 
 func (p *dlnaPlayer) startHTTPServer() {
@@ -396,6 +397,11 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 		return
 	}
 
+	// 同步获取当前位置，确保 PassedTime() 立即准确
+	if curPos, _, err := p.getPositionInfo(); err == nil {
+		p.curPos = curPos
+	}
+
 	slog.Info("DLNA: starting playback")
 	if err := p.soapRequest("AVTransport", "Play", playBody); err != nil {
 		slog.Error("DLNA: Play failed", "error", err)
@@ -404,11 +410,6 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 
 	p.state = types.Playing
 	p.stateChan <- p.state
-
-	if !p.polling {
-		p.polling = true
-		go p.pollPositionInfo()
-	}
 }
 
 func (p *dlnaPlayer) pollPositionInfo() {
@@ -417,10 +418,7 @@ func (p *dlnaPlayer) pollPositionInfo() {
 	for {
 		select {
 		case <-ticker.C:
-			// 仅在播放状态时执行轮询
-			if !p.polling {
-				return
-			}
+			// 保持連接活躍：DLNA 設備空閒會關閉連接，需持續輪詢避免
 			state, _ := p.getTransportInfo()
 			if state == "STOPPED" || state == "NO_MEDIA_PRESENT" {
 				p.state = types.Stopped
@@ -498,9 +496,6 @@ func (p *dlnaPlayer) Pause() {
 	}
 	p.state = types.Paused
 	p.stateChan <- p.state
-
-	// 暂停时停止轮询
-	p.polling = false
 }
 
 func (p *dlnaPlayer) Resume() {
@@ -526,9 +521,6 @@ func (p *dlnaPlayer) Stop() {
 	p.curPos = 0
 	p.state = types.Stopped
 	p.stateChan <- p.state
-
-	// 停止时停止轮询
-	p.polling = false
 }
 
 func (p *dlnaPlayer) Toggle() {

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -70,6 +70,23 @@ const setVolumeBody = `<u:SetVolume xmlns:u="urn:schemas-upnp-org:service:Render
   <DesiredVolume>%d</DesiredVolume>
 </u:SetVolume>`
 
+type cmdType int
+
+const (
+	cmdPlay cmdType = iota
+	cmdPause
+	cmdResume
+	cmdStop
+	cmdSeek
+	cmdSetVolume
+)
+
+type command struct {
+	cmd    cmdType
+	param  any
+	result chan<- any
+}
+
 type dlnaPlayer struct {
 	deviceURL           string
 	controlURL          string
@@ -79,9 +96,8 @@ type dlnaPlayer struct {
 	httpClient          *http.Client
 	state               types.State
 	stateChan           chan types.State
-	musicChan           chan URLMusic
 	closed              chan struct{}
-	ready               chan struct{}
+	cmdQueue            chan command
 
 	curPos   time.Duration
 	timeChan chan time.Duration
@@ -107,11 +123,10 @@ func NewDlnaPlayer(deviceURL, localIP string) (Player, error) {
 		httpClient: &http.Client{Timeout: 1 * time.Second},
 		state:      types.Stopped,
 		stateChan:  make(chan types.State, 10),
-		musicChan:  make(chan URLMusic, 10),
 		closed:     make(chan struct{}),
-		ready:      make(chan struct{}),
 		timeChan:   make(chan time.Duration, 1),
 		fileMap:    make(map[int64]string),
+		cmdQueue:   make(chan command, 10),
 	}
 	if err := p.startHTTPServer(); err != nil {
 		return nil, err
@@ -120,6 +135,7 @@ func NewDlnaPlayer(deviceURL, localIP string) (Player, error) {
 		p.Close()
 		return nil, err
 	}
+	go p.worker()
 	return p, nil
 }
 
@@ -139,8 +155,6 @@ type dlnaService struct {
 }
 
 func (p *dlnaPlayer) initControlURL() error {
-	defer close(p.ready)
-
 	slog.Debug("DLNA: fetching device description", "url", p.deviceURL)
 	resp, err := p.httpClient.Get(p.deviceURL)
 	if err != nil {
@@ -192,9 +206,117 @@ func (p *dlnaPlayer) initControlURL() error {
 		slog.Error("DLNA: RenderingControl service not found")
 	}
 
-	// Start polling after initialization to keep connection alive
-	go p.pollState()
 	return nil
+}
+
+func (p *dlnaPlayer) worker() {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			p.pollStateTask()
+		case cmd := <-p.cmdQueue:
+			p.executeCmd(cmd)
+		case <-p.closed:
+			return
+		}
+	}
+}
+
+func (p *dlnaPlayer) pollStateTask() {
+	state, _ := p.getTransportInfo()
+	if state == "STOPPED" || state == "NO_MEDIA_PRESENT" {
+		p.state = types.Stopped
+		p.sendState()
+		return
+	}
+	curPos, _, _ := p.getPositionInfo()
+	if curPos > 0 {
+		p.curPos = curPos
+		select {
+		case p.timeChan <- curPos:
+		default:
+		}
+	}
+	if vol, err := p.getVolume(); err == nil {
+		p.cachedVolume = vol
+	}
+}
+
+func (p *dlnaPlayer) executeCmd(cmd command) {
+	switch cmd.cmd {
+	case cmdPlay:
+		music := cmd.param.(URLMusic)
+		p.audioURL = music.URL
+		p.audioDur = music.Duration
+		p.fileMapMu.Lock()
+		for k := range p.fileMap {
+			delete(p.fileMap, k)
+		}
+		p.fileMapMu.Unlock()
+		audioURL := music.URL
+		if strings.HasPrefix(audioURL, "file://") {
+			localPath := strings.TrimPrefix(audioURL, "file://")
+			p.fileMapMu.Lock()
+			p.fileMap[music.Id] = localPath
+			p.fileMapMu.Unlock()
+			audioURL = fmt.Sprintf("http://%s:%d/dlna/%d", p.localIP, p.httpPort, music.Id)
+		}
+		p.audioURL = audioURL
+
+		slog.Info("DLNA: setting AVTransport URI", "audioURL", p.audioURL)
+		p.doSOAP("AVTransport", "SetAVTransportURI", fmt.Sprintf(setAvTransportURIBody, p.audioURL))
+
+		slog.Info("DLNA: starting playback")
+		p.doSOAP("AVTransport", "Play", playBody)
+
+		p.state = types.Playing
+		p.sendState()
+		p.startTime = time.Now()
+		p.pausedTime = 0
+		p.wasEverPlayed = true
+		cmd.result <- true
+
+	case cmdPause:
+		p.doSOAP("AVTransport", "Pause", pauseBody)
+		p.state = types.Paused
+		p.sendState()
+		p.pauseStart = time.Now()
+		cmd.result <- true
+
+	case cmdResume:
+		p.doSOAP("AVTransport", "Play", playBody)
+		p.state = types.Playing
+		p.sendState()
+		p.pausedTime += time.Since(p.pauseStart)
+		cmd.result <- true
+
+	case cmdStop:
+		p.doSOAP("AVTransport", "Stop", stopBody)
+		p.curPos = 0
+		p.state = types.Stopped
+		p.sendState()
+		p.startTime = time.Time{}
+		p.pausedTime = 0
+		p.wasEverPlayed = false
+		cmd.result <- true
+
+	case cmdSeek:
+		duration := cmd.param.(time.Duration)
+		seekTime := formatDuration(duration)
+		p.doSOAP("AVTransport", "Seek", fmt.Sprintf(seekBody, seekTime))
+		cmd.result <- true
+
+	case cmdSetVolume:
+		volume := cmd.param.(int)
+		if volume >= 0 && volume <= 100 && volume != p.cachedVolume {
+			body := fmt.Sprintf(setVolumeBody, volume)
+			p.doSOAP("RenderingControl", "SetVolume", body)
+			p.cachedVolume = volume
+		}
+		cmd.result <- true
+	}
 }
 
 func (p *dlnaPlayer) startHTTPServer() error {
@@ -314,83 +436,13 @@ func (p *dlnaPlayer) sendState() {
 }
 
 func (p *dlnaPlayer) Play(music URLMusic) {
-	// Clear fileMap to avoid memory leak
-	p.fileMapMu.Lock()
-	for k := range p.fileMap {
-		delete(p.fileMap, k)
+	result := make(chan any)
+	p.cmdQueue <- command{
+		cmd:    cmdPlay,
+		param:  music,
+		result: result,
 	}
-	p.fileMapMu.Unlock()
-
-	audioURL := music.URL
-
-	if strings.HasPrefix(audioURL, "file://") {
-		localPath := strings.TrimPrefix(audioURL, "file://")
-		p.fileMapMu.Lock()
-		p.fileMap[music.Id] = localPath
-		p.fileMapMu.Unlock()
-		audioURL = fmt.Sprintf("http://%s:%d/dlna/%d", p.localIP, p.httpPort, music.Id)
-		slog.Debug("DLNA: converted file URL", "original", music.URL, "converted", audioURL)
-	}
-
-	p.audioURL = audioURL
-	p.audioDur = music.Duration
-	p.musicChan <- music
-
-	select {
-	case <-p.ready:
-	case <-time.After(2 * time.Second):
-		slog.Error("DLNA: timeout waiting for control URL init")
-		return
-	}
-
-	slog.Info("DLNA: setting AVTransport URI", "audioURL", p.audioURL)
-	if _, err := p.doSOAP("AVTransport", "SetAVTransportURI", fmt.Sprintf(setAvTransportURIBody, p.audioURL)); err != nil {
-		slog.Error("DLNA: SetAVTransportURI failed", "error", err)
-		return
-	}
-
-	slog.Info("DLNA: starting playback")
-	if _, err := p.doSOAP("AVTransport", "Play", playBody); err != nil {
-		slog.Error("DLNA: Play failed", "error", err)
-		return
-	}
-
-	p.state = types.Playing
-	p.sendState()
-
-	// 初始化播放计时
-	p.startTime = time.Now()
-	p.pausedTime = 0
-	p.wasEverPlayed = true
-}
-
-func (p *dlnaPlayer) pollState() {
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			state, _ := p.getTransportInfo()
-			if state == "STOPPED" || state == "NO_MEDIA_PRESENT" {
-				p.state = types.Stopped
-				p.sendState()
-				continue
-			}
-			curPos, _, _ := p.getPositionInfo()
-			if curPos > 0 {
-				p.curPos = curPos
-				select {
-				case p.timeChan <- curPos:
-				default:
-				}
-			}
-			if vol, err := p.getVolume(); err == nil {
-				p.cachedVolume = vol
-			}
-		case <-p.closed:
-			return
-		}
-	}
+	<-result
 }
 
 func (p *dlnaPlayer) getTransportInfo() (string, error) {
@@ -430,42 +482,21 @@ func (p *dlnaPlayer) CurMusic() URLMusic {
 }
 
 func (p *dlnaPlayer) Pause() {
-	if _, err := p.doSOAP("AVTransport", "Pause", pauseBody); err != nil {
-		slog.Error("DLNA: Pause failed", "error", err)
-		return
-	}
-	p.state = types.Paused
-	p.sendState()
-
-	// 记录暂停时刻
-	p.pauseStart = time.Now()
+	result := make(chan any)
+	p.cmdQueue <- command{cmd: cmdPause, result: result}
+	<-result
 }
 
 func (p *dlnaPlayer) Resume() {
-	if _, err := p.doSOAP("AVTransport", "Play", playBody); err != nil {
-		slog.Error("DLNA: Resume failed", "error", err)
-		return
-	}
-	p.state = types.Playing
-	p.sendState()
-
-	// 累加暂停时长
-	p.pausedTime += time.Since(p.pauseStart)
+	result := make(chan any)
+	p.cmdQueue <- command{cmd: cmdResume, result: result}
+	<-result
 }
 
 func (p *dlnaPlayer) Stop() {
-	if _, err := p.doSOAP("AVTransport", "Stop", stopBody); err != nil {
-		slog.Error("DLNA: Stop failed", "error", err)
-		return
-	}
-	p.curPos = 0
-	p.state = types.Stopped
-	p.sendState()
-
-	// 重置播放计时
-	p.startTime = time.Time{}
-	p.pausedTime = 0
-	p.wasEverPlayed = false
+	result := make(chan any)
+	p.cmdQueue <- command{cmd: cmdStop, result: result}
+	<-result
 }
 
 func (p *dlnaPlayer) Toggle() {
@@ -477,10 +508,9 @@ func (p *dlnaPlayer) Toggle() {
 }
 
 func (p *dlnaPlayer) Seek(duration time.Duration) {
-	seekTime := formatDuration(duration)
-	if _, err := p.doSOAP("AVTransport", "Seek", fmt.Sprintf(seekBody, seekTime)); err != nil {
-		slog.Debug("DLNA: Seek not supported", "error", err)
-	}
+	result := make(chan any)
+	p.cmdQueue <- command{cmd: cmdSeek, param: duration, result: result}
+	<-result
 }
 
 func (p *dlnaPlayer) PassedTime() time.Duration {
@@ -530,14 +560,9 @@ func (p *dlnaPlayer) Volume() int {
 }
 
 func (p *dlnaPlayer) SetVolume(volume int) {
-	if volume >= 0 && volume <= 100 && volume != p.cachedVolume {
-		body := fmt.Sprintf(setVolumeBody, volume)
-		if _, err := p.doSOAP("RenderingControl", "SetVolume", body); err != nil {
-			slog.Error("DLNA: SetVolume failed", "error", err)
-			return
-		}
-		p.cachedVolume = volume
-	}
+	result := make(chan any)
+	p.cmdQueue <- command{cmd: cmdSetVolume, param: volume, result: result}
+	<-result
 }
 
 func (p *dlnaPlayer) UpVolume() {

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -591,24 +591,13 @@ func (p *dlnaPlayer) getVolume() (int, error) {
 	return volume, nil
 }
 
-func (p *dlnaPlayer) setVolume(volume int) error {
-	body := fmt.Sprintf(setVolumeBody, volume)
-	_, _, err := p.renderControlSOAPRequest("SetVolume", body)
-	return err
-}
-
 func (p *dlnaPlayer) Volume() int {
 	return p.cachedVolume
 }
 
 func (p *dlnaPlayer) SetVolume(volume int) {
-	if volume < 0 {
-		volume = 0
-	}
-	if volume > 100 {
-		volume = 100
-	}
-	if err := p.setVolume(volume); err != nil {
+	body := fmt.Sprintf(setVolumeBody, volume)
+	if err := p.soapRequest("RenderingControl", "SetVolume", body); err != nil {
 		slog.Error("DLNA: SetVolume failed", "error", err)
 		return
 	}
@@ -616,17 +605,11 @@ func (p *dlnaPlayer) SetVolume(volume int) {
 }
 
 func (p *dlnaPlayer) UpVolume() {
-	current := p.Volume()
-	if current < 100 {
-		p.SetVolume(current + 1)
-	}
+	p.SetVolume(p.Volume() + 1)
 }
 
 func (p *dlnaPlayer) DownVolume() {
-	current := p.Volume()
-	if current > 0 {
-		p.SetVolume(current - 1)
-	}
+	p.SetVolume(p.Volume() - 1)
 }
 
 func (p *dlnaPlayer) Close() {

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -426,7 +426,7 @@ func (p *dlnaPlayer) getPositionInfo() (time.Duration, time.Duration, error) {
 	return curPos, totalDur, nil
 }
 
-// sendState 非阻塞发送状态更新，带 2 秒超时
+// sendState sends state update non-blockingly, with 2 second timeout
 func (p *dlnaPlayer) sendState() {
 	select {
 	case p.stateChan <- p.state:

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -168,19 +168,12 @@ func (p *dlnaPlayer) initControlURL() {
 
 	for _, svc := range r.Device.Services {
 		slog.Debug("DLNA: found service", "type", svc.ServiceType, "controlURL", svc.ControlURL)
+		controlURL := p.normalizeURL(base, svc.ControlURL)
 		switch svc.ServiceType {
 		case "urn:schemas-upnp-org:service:AVTransport:1":
-			controlURL := svc.ControlURL
-			if controlURL != "" && !bytes.HasPrefix([]byte(controlURL), []byte("http")) {
-				controlURL = base + controlURL
-			}
 			p.controlURL = controlURL
 			slog.Info("DLNA: found AVTransport control URL", "url", controlURL)
 		case "urn:schemas-upnp-org:service:RenderingControl:1":
-			controlURL := svc.ControlURL
-			if controlURL != "" && !bytes.HasPrefix([]byte(controlURL), []byte("http")) {
-				controlURL = base + controlURL
-			}
 			p.renderingControlURL = controlURL
 			slog.Info("DLNA: found RenderingControl control URL", "url", controlURL)
 		}
@@ -231,19 +224,18 @@ func (p *dlnaPlayer) serveLocalFile(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, path)
 }
 
-func (p *dlnaPlayer) getPositionInfo() (time.Duration, time.Duration, error) {
-	body := getPositionInfoBody
+func (p *dlnaPlayer) executeSOAPRequest(controlURL, action, body string) ([]byte, error) {
 	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
-	req, err := http.NewRequest("POST", p.controlURL, bytes.NewBufferString(envelope))
+	req, err := http.NewRequest("POST", controlURL, bytes.NewBufferString(envelope))
 	if err != nil {
-		return 0, 0, err
+		return nil, err
 	}
 	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
-	req.Header.Set("SOAPAction", `"urn:schemas-upnp-org:service:AVTransport:1#GetPositionInfo"`)
+	req.Header.Set("SOAPAction", fmt.Sprintf(`"urn:schemas-upnp-org:service:%s"`, action))
 
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
-		return 0, 0, err
+		return nil, err
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -252,10 +244,21 @@ func (p *dlnaPlayer) getPositionInfo() (time.Duration, time.Duration, error) {
 	}()
 
 	if resp.StatusCode >= 400 {
-		return 0, 0, fmt.Errorf("GetPositionInfo failed: %d", resp.StatusCode)
+		return nil, fmt.Errorf("%s failed: %d", action, resp.StatusCode)
 	}
 
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return respBody, nil
+}
+
+func (p *dlnaPlayer) getPositionInfo() (time.Duration, time.Duration, error) {
+	respBody, err := p.executeSOAPRequest(p.controlURL, "AVTransport:1#GetPositionInfo", getPositionInfoBody)
+	if err != nil {
+		return 0, 0, err
+	}
 
 	type positionInfoResponse struct {
 		Track         string `xml:"Track"`
@@ -454,29 +457,10 @@ func (p *dlnaPlayer) pollPositionInfo() {
 }
 
 func (p *dlnaPlayer) getTransportInfo() (string, error) {
-	envelope := fmt.Sprintf(soapEnvelopeTpl, getTransportInfoBody)
-	req, err := http.NewRequest("POST", p.controlURL, bytes.NewBufferString(envelope))
+	respBody, err := p.executeSOAPRequest(p.controlURL, "AVTransport:1#GetTransportInfo", getTransportInfoBody)
 	if err != nil {
 		return "", err
 	}
-	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
-	req.Header.Set("SOAPAction", `"urn:schemas-upnp-org:service:AVTransport:1#GetTransportInfo"`)
-
-	resp, err := p.httpClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			slog.Error("DLNA: failed to close response body", "error", err)
-		}
-	}()
-
-	if resp.StatusCode >= 400 {
-		return "", fmt.Errorf("GetTransportInfo failed: %d", resp.StatusCode)
-	}
-
-	respBody, _ := io.ReadAll(resp.Body)
 
 	type transportInfoResponse struct {
 		CurrentTransportState string `xml:"CurrentTransportState"`
@@ -494,6 +478,13 @@ func (p *dlnaPlayer) getTransportInfo() (string, error) {
 	}
 
 	return env.Body.GetTransportInfoResponse.CurrentTransportState, nil
+}
+
+func (p *dlnaPlayer) normalizeURL(base, controlURL string) string {
+	if controlURL != "" && !bytes.HasPrefix([]byte(controlURL), []byte("http")) {
+		controlURL = base + controlURL
+	}
+	return controlURL
 }
 
 func (p *dlnaPlayer) CurMusic() URLMusic {

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -380,6 +380,10 @@ func (p *dlnaPlayer) pollPositionInfo() {
 	for {
 		select {
 		case <-ticker.C:
+			// 仅在播放状态时执行轮询
+			if !p.polling {
+				return
+			}
 			state, _ := p.getTransportInfo()
 			if state == "STOPPED" || state == "NO_MEDIA_PRESENT" {
 				p.state = types.Stopped
@@ -457,6 +461,9 @@ func (p *dlnaPlayer) Pause() {
 	}
 	p.state = types.Paused
 	p.stateChan <- p.state
+
+	// 暂停时停止轮询
+	p.polling = false
 }
 
 func (p *dlnaPlayer) Resume() {
@@ -482,6 +489,9 @@ func (p *dlnaPlayer) Stop() {
 	p.curPos = 0
 	p.state = types.Stopped
 	p.stateChan <- p.state
+
+	// 停止时停止轮询
+	p.polling = false
 }
 
 func (p *dlnaPlayer) Toggle() {

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -3,12 +3,15 @@ package player
 import (
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-musicfox/go-musicfox/internal/types"
@@ -70,11 +73,18 @@ type dlnaPlayer struct {
 	timeChan chan time.Duration
 
 	polling bool
+
+	httpServer *http.Server
+	httpPort   int
+	localIP    string
+	fileMap    map[int64]string
+	fileMapMu  sync.RWMutex
 }
 
-func NewDlnaPlayer(deviceUrl string) *dlnaPlayer {
+func NewDlnaPlayer(deviceUrl, localIP string) *dlnaPlayer {
 	p := &dlnaPlayer{
 		deviceUrl:  deviceUrl,
+		localIP:    localIP,
 		httpClient: &http.Client{Timeout: 10 * time.Second},
 		state:      types.Stopped,
 		stateChan:  make(chan types.State, 10),
@@ -82,7 +92,9 @@ func NewDlnaPlayer(deviceUrl string) *dlnaPlayer {
 		closed:     make(chan struct{}),
 		ready:      make(chan struct{}),
 		timeChan:   make(chan time.Duration, 1),
+		fileMap:    make(map[int64]string),
 	}
+	p.startHTTPServer()
 	go p.initControlUrl()
 	return p
 }
@@ -145,6 +157,40 @@ func (p *dlnaPlayer) initControlUrl() {
 		}
 	}
 	slog.Error("DLNA: AVTransport service not found")
+}
+
+func (p *dlnaPlayer) startHTTPServer() {
+	if p.localIP == "" {
+		panic("DLNA: localIP is required in config [player.dlna].localIP")
+	}
+	for i := 0; i < 10; i++ {
+		listener, err := net.Listen("tcp", p.localIP+":0")
+		if err != nil {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		p.httpPort = listener.Addr().(*net.TCPAddr).Port
+		mux := http.NewServeMux()
+		mux.HandleFunc("/dlna/", p.serveLocalFile)
+		p.httpServer = &http.Server{Handler: mux}
+		go func() {
+			if err := p.httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				slog.Error("DLNA: HTTP server error", "error", err)
+			}
+		}()
+		slog.Info("DLNA: HTTP server started", "bind", p.localIP, "port", p.httpPort)
+		return
+	}
+	panic("DLNA: failed to start HTTP server after 10 attempts")
+}
+
+func (p *dlnaPlayer) serveLocalFile(w http.ResponseWriter, r *http.Request) {
+	songIDStr := strings.TrimPrefix(r.URL.Path, "/dlna/")
+	songID, _ := strconv.ParseInt(songIDStr, 10, 64)
+	p.fileMapMu.RLock()
+	path := p.fileMap[songID]
+	p.fileMapMu.RUnlock()
+	http.ServeFile(w, r, path)
 }
 
 func (p *dlnaPlayer) getPositionInfo() (time.Duration, time.Duration, error) {
@@ -244,7 +290,23 @@ func (p *dlnaPlayer) soapRequest(action, body string) error {
 }
 
 func (p *dlnaPlayer) Play(music URLMusic) {
-	p.audioUrl = music.URL
+	// 清理 fileMap，避免内存泄漏
+	p.fileMapMu.Lock()
+	p.fileMap = make(map[int64]string)
+	p.fileMapMu.Unlock()
+
+	audioURL := music.URL
+
+	if strings.HasPrefix(audioURL, "file://") {
+		localPath := strings.TrimPrefix(audioURL, "file://")
+		p.fileMapMu.Lock()
+		p.fileMap[music.Id] = localPath
+		p.fileMapMu.Unlock()
+		audioURL = fmt.Sprintf("http://%s:%d/dlna/%d", p.localIP, p.httpPort, music.Id)
+		slog.Debug("DLNA: converted file URL", "original", music.URL, "converted", audioURL)
+	}
+
+	p.audioUrl = audioURL
 	p.audioDur = music.Duration
 	p.musicChan <- music
 
@@ -433,6 +495,9 @@ func (p *dlnaPlayer) DownVolume() {}
 
 func (p *dlnaPlayer) Close() {
 	close(p.closed)
+	if p.httpServer != nil {
+		p.httpServer.Close()
+	}
 }
 
 func formatDuration(d time.Duration) string {

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -289,6 +290,31 @@ func (p *dlnaPlayer) soapRequest(action, body string) error {
 	return nil
 }
 
+func isFileReady(path string) bool {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if fi.Size() == 0 {
+		return false
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	_ = f.Close()
+	return true
+}
+
+func (p *dlnaPlayer) waitForFileReady(path string) {
+	for i := 0; i < 10; i++ {
+		if isFileReady(path) {
+			return
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
+
 func (p *dlnaPlayer) Play(music URLMusic) {
 	// 清理 fileMap，避免内存泄漏
 	p.fileMapMu.Lock()
@@ -299,6 +325,11 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 
 	if strings.HasPrefix(audioURL, "file://") {
 		localPath := strings.TrimPrefix(audioURL, "file://")
+		p.waitForFileReady(localPath)
+		if !isFileReady(localPath) {
+			slog.Error("DLNA: cache file not ready", "path", localPath)
+			return
+		}
 		p.fileMapMu.Lock()
 		p.fileMap[music.Id] = localPath
 		p.fileMapMu.Unlock()
@@ -344,7 +375,7 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 }
 
 func (p *dlnaPlayer) pollPositionInfo() {
-	ticker := time.NewTicker(2 * time.Second)
+	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	for {
 		select {

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -294,6 +294,15 @@ func (p *dlnaPlayer) getPositionInfo() (time.Duration, time.Duration, error) {
 	return curPos, totalDur, nil
 }
 
+// sendState 非阻塞发送状态更新，带 2 秒超时
+func (p *dlnaPlayer) sendState() {
+	select {
+	case p.stateChan <- p.state:
+	case <-time.After(time.Second * 2):
+		slog.Warn("DLNA: stateChan send timeout, drop state update")
+	}
+}
+
 func (p *dlnaPlayer) Play(music URLMusic) {
 	// 清理 fileMap，避免内存泄漏
 	p.fileMapMu.Lock()
@@ -335,7 +344,7 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 	}
 
 	p.state = types.Playing
-	p.stateChan <- p.state
+	p.sendState()
 
 	// 初始化播放计时
 	p.startTime = time.Now()
@@ -352,7 +361,7 @@ func (p *dlnaPlayer) pollState() {
 			state, _ := p.getTransportInfo()
 			if state == "STOPPED" || state == "NO_MEDIA_PRESENT" {
 				p.state = types.Stopped
-				p.stateChan <- p.state
+				p.sendState()
 				continue
 			}
 			curPos, _, _ := p.getPositionInfo()
@@ -414,7 +423,7 @@ func (p *dlnaPlayer) Pause() {
 		return
 	}
 	p.state = types.Paused
-	p.stateChan <- p.state
+	p.sendState()
 
 	// 记录暂停时刻
 	p.pauseStart = time.Now()
@@ -426,7 +435,7 @@ func (p *dlnaPlayer) Resume() {
 		return
 	}
 	p.state = types.Playing
-	p.stateChan <- p.state
+	p.sendState()
 
 	// 累加暂停时长
 	p.pausedTime += time.Since(p.pauseStart)
@@ -439,7 +448,7 @@ func (p *dlnaPlayer) Stop() {
 	}
 	p.curPos = 0
 	p.state = types.Stopped
-	p.stateChan <- p.state
+	p.sendState()
 
 	// 重置播放计时
 	p.startTime = time.Time{}

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -92,6 +92,11 @@ type dlnaPlayer struct {
 	localIP    string
 	fileMap    map[int64]string
 	fileMapMu  sync.RWMutex
+
+	startTime     time.Time
+	pausedTime    time.Duration
+	pauseStart    time.Time
+	wasEverPlayed bool
 }
 
 func NewDlnaPlayer(deviceURL, localIP string) *dlnaPlayer {
@@ -414,6 +419,11 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 
 	p.state = types.Playing
 	p.stateChan <- p.state
+
+	// 初始化播放计时
+	p.startTime = time.Now()
+	p.pausedTime = 0
+	p.wasEverPlayed = true
 }
 
 func (p *dlnaPlayer) pollPositionInfo() {
@@ -501,6 +511,9 @@ func (p *dlnaPlayer) Pause() {
 	}
 	p.state = types.Paused
 	p.stateChan <- p.state
+
+	// 记录暂停时刻
+	p.pauseStart = time.Now()
 }
 
 func (p *dlnaPlayer) Resume() {
@@ -510,6 +523,9 @@ func (p *dlnaPlayer) Resume() {
 	}
 	p.state = types.Playing
 	p.stateChan <- p.state
+
+	// 累加暂停时长
+	p.pausedTime += time.Since(p.pauseStart)
 }
 
 func (p *dlnaPlayer) Stop() {
@@ -520,6 +536,11 @@ func (p *dlnaPlayer) Stop() {
 	p.curPos = 0
 	p.state = types.Stopped
 	p.stateChan <- p.state
+
+	// 重置播放计时
+	p.startTime = time.Time{}
+	p.pausedTime = 0
+	p.wasEverPlayed = false
 }
 
 func (p *dlnaPlayer) Toggle() {
@@ -541,7 +562,12 @@ func (p *dlnaPlayer) PassedTime() time.Duration {
 	return p.curPos
 }
 
-func (p *dlnaPlayer) PlayedTime() time.Duration { return 0 }
+func (p *dlnaPlayer) PlayedTime() time.Duration {
+	if !p.wasEverPlayed {
+		return 0
+	}
+	return time.Since(p.startTime) - p.pausedTime
+}
 
 func (p *dlnaPlayer) TimeChan() <-chan time.Duration {
 	return p.timeChan

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -1,0 +1,229 @@
+package player
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-musicfox/go-musicfox/internal/types"
+)
+
+const soapEnvelopeTpl = `<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+  <s:Body>
+    %s
+  </s:Body>
+</s:Envelope>`
+
+const setAvTransportUriBody = `<u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+  <InstanceID>0</InstanceID>
+  <CurrentURI>%s</CurrentURI>
+  <CurrentURIMetaData></CurrentURIMetaData>
+</u:SetAVTransportURI>`
+
+const playBody = `<u:Play xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+  <InstanceID>0</InstanceID>
+  <Speed>1</Speed>
+</u:Play>`
+
+type dlnaPlayer struct {
+	deviceUrl  string
+	controlUrl string
+	audioUrl   string
+	httpClient *http.Client
+	state      types.State
+	stateChan  chan types.State
+	musicChan  chan URLMusic
+	closed     chan struct{}
+	ready      chan struct{}
+}
+
+func NewDlnaPlayer(deviceUrl string) *dlnaPlayer {
+	p := &dlnaPlayer{
+		deviceUrl:  deviceUrl,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		state:      types.Stopped,
+		stateChan:  make(chan types.State, 10),
+		musicChan:  make(chan URLMusic, 10),
+		closed:     make(chan struct{}),
+		ready:      make(chan struct{}),
+	}
+	go p.initControlUrl()
+	return p
+}
+
+type dlnaRoot struct {
+	XMLName xml.Name   `xml:"root"`
+	URLBase string     `xml:"URLBase"`
+	Device  dlnaDevice `xml:"device"`
+}
+
+type dlnaDevice struct {
+	Services []dlnaService `xml:"serviceList>service"`
+}
+
+type dlnaService struct {
+	ServiceType string `xml:"serviceType"`
+	ControlURL  string `xml:"controlURL"`
+}
+
+func (p *dlnaPlayer) initControlUrl() {
+	defer close(p.ready)
+
+	slog.Debug("DLNA: fetching device description", "url", p.deviceUrl)
+	resp, err := p.httpClient.Get(p.deviceUrl)
+	if err != nil {
+		slog.Error("DLNA: failed to fetch device description", "error", err)
+		return
+	}
+	defer resp.Body.Close()
+	xmlData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		slog.Error("DLNA: failed to read device description", "error", err)
+		return
+	}
+
+	var r dlnaRoot
+	if err := xml.Unmarshal(xmlData, &r); err != nil {
+		slog.Error("DLNA: failed to parse device description", "error", err)
+		slog.Debug("DLNA: raw XML", "data", string(xmlData))
+		return
+	}
+
+	base := r.URLBase
+	if base == "" {
+		base = p.deviceUrl[:len(p.deviceUrl)-len("/description.xml")] + "/"
+	}
+	base = strings.TrimRight(base, "/")
+	slog.Debug("DLNA: using base URL", "base", base)
+
+	for _, svc := range r.Device.Services {
+		slog.Debug("DLNA: found service", "type", svc.ServiceType, "controlUrl", svc.ControlURL)
+		if svc.ServiceType == "urn:schemas-upnp-org:service:AVTransport:1" {
+			controlUrl := svc.ControlURL
+			if controlUrl != "" && !bytes.HasPrefix([]byte(controlUrl), []byte("http")) {
+				controlUrl = base + controlUrl
+			}
+			p.controlUrl = controlUrl
+			slog.Info("DLNA: found AVTransport control URL", "url", controlUrl)
+			return
+		}
+	}
+	slog.Error("DLNA: AVTransport service not found")
+}
+
+func (p *dlnaPlayer) soapRequest(action, body string) error {
+	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
+	req, err := http.NewRequest("POST", p.controlUrl, bytes.NewBufferString(envelope))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
+	req.Header.Set("SOAPAction", fmt.Sprintf(`"urn:schemas-upnp-org:service:AVTransport:1#%s"`, action))
+
+	slog.Debug("DLNA: SOAP request", "action", action, "url", p.controlUrl)
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		slog.Error("DLNA: SOAP request failed", "action", action, "error", err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	slog.Debug("DLNA: SOAP response", "action", action, "status", resp.StatusCode, "body", string(respBody))
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("soap request failed: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (p *dlnaPlayer) Play(music URLMusic) {
+	p.audioUrl = music.URL
+	p.musicChan <- music
+
+	select {
+	case <-p.ready:
+	case <-time.After(2 * time.Second):
+		slog.Error("DLNA: timeout waiting for control URL init")
+		return
+	}
+
+	if p.controlUrl == "" {
+		slog.Error("DLNA: control URL not found")
+		return
+	}
+
+	slog.Info("DLNA: setting AVTransport URI", "audioUrl", p.audioUrl)
+	if err := p.soapRequest("SetAVTransportURI", fmt.Sprintf(setAvTransportUriBody, p.audioUrl)); err != nil {
+		slog.Error("DLNA: SetAVTransportURI failed", "error", err)
+		return
+	}
+
+	slog.Info("DLNA: starting playback")
+	if err := p.soapRequest("Play", playBody); err != nil {
+		slog.Error("DLNA: Play failed", "error", err)
+		return
+	}
+
+	p.state = types.Playing
+	p.stateChan <- p.state
+}
+
+func (p *dlnaPlayer) CurMusic() URLMusic {
+	return URLMusic{URL: p.audioUrl}
+}
+
+func (p *dlnaPlayer) Pause() {
+	p.state = types.Paused
+	p.stateChan <- p.state
+}
+
+func (p *dlnaPlayer) Resume() {
+	p.state = types.Playing
+	p.stateChan <- p.state
+}
+
+func (p *dlnaPlayer) Stop() {
+	p.state = types.Stopped
+	p.stateChan <- p.state
+}
+
+func (p *dlnaPlayer) Toggle() {
+	if p.state == types.Playing {
+		p.Pause()
+	} else {
+		p.Resume()
+	}
+}
+
+func (p *dlnaPlayer) Seek(duration time.Duration) {}
+
+func (p *dlnaPlayer) PassedTime() time.Duration { return 0 }
+
+func (p *dlnaPlayer) PlayedTime() time.Duration { return 0 }
+
+func (p *dlnaPlayer) TimeChan() <-chan time.Duration {
+	return make(chan time.Duration)
+}
+
+func (p *dlnaPlayer) State() types.State { return p.state }
+
+func (p *dlnaPlayer) StateChan() <-chan types.State { return p.stateChan }
+
+func (p *dlnaPlayer) Volume() int { return 0 }
+
+func (p *dlnaPlayer) SetVolume(volume int) {}
+
+func (p *dlnaPlayer) UpVolume() {}
+
+func (p *dlnaPlayer) DownVolume() {}
+
+func (p *dlnaPlayer) Close() {
+	close(p.closed)
+}

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -182,7 +182,7 @@ func (p *dlnaPlayer) initControlURL() {
 	}
 
 	if p.controlURL == "" {
-		slog.Error("DLNA: AVTransport service not found")
+		panic("DLNA: AVTransport service not found or invalid")
 	}
 	if p.renderingControlURL == "" {
 		slog.Error("DLNA: RenderingControl service not found")
@@ -302,17 +302,12 @@ func parseTime(t string) time.Duration {
 
 func (p *dlnaPlayer) soapRequest(service, action, body string) error {
 	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
-	var controlURL string
-	switch service {
-	case "AVTransport":
-		controlURL = p.controlURL
-	case "RenderingControl":
+	controlURL := p.controlURL
+	if service == "RenderingControl" {
 		controlURL = p.renderingControlURL
-	default:
-		return fmt.Errorf("unknown service: %s", service)
-	}
-	if controlURL == "" {
-		return fmt.Errorf("control URL for service %s not available", service)
+		if controlURL == "" {
+			return fmt.Errorf("RenderingControl service not available")
+		}
 	}
 	req, err := http.NewRequest("POST", controlURL, bytes.NewBufferString(envelope))
 	if err != nil {
@@ -363,7 +358,7 @@ func (p *dlnaPlayer) waitForFileReady(path string) {
 		if isFileReady(path) {
 			return
 		}
-		time.Sleep(1 * time.Second)
+		time.Sleep(3 * time.Second)
 	}
 }
 
@@ -397,11 +392,6 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 	case <-p.ready:
 	case <-time.After(2 * time.Second):
 		slog.Error("DLNA: timeout waiting for control URL init")
-		return
-	}
-
-	if p.controlURL == "" {
-		slog.Error("DLNA: control URL not found")
 		return
 	}
 
@@ -505,9 +495,6 @@ func (p *dlnaPlayer) CurMusic() URLMusic {
 }
 
 func (p *dlnaPlayer) Pause() {
-	if p.controlURL == "" {
-		return
-	}
 	if err := p.soapRequest("AVTransport", "Pause", pauseBody); err != nil {
 		slog.Error("DLNA: Pause failed", "error", err)
 		return
@@ -517,9 +504,6 @@ func (p *dlnaPlayer) Pause() {
 }
 
 func (p *dlnaPlayer) Resume() {
-	if p.controlURL == "" {
-		return
-	}
 	if err := p.soapRequest("AVTransport", "Play", playBody); err != nil {
 		slog.Error("DLNA: Resume failed", "error", err)
 		return
@@ -529,9 +513,6 @@ func (p *dlnaPlayer) Resume() {
 }
 
 func (p *dlnaPlayer) Stop() {
-	if p.controlURL == "" {
-		return
-	}
 	if err := p.soapRequest("AVTransport", "Stop", stopBody); err != nil {
 		slog.Error("DLNA: Stop failed", "error", err)
 		return
@@ -550,9 +531,6 @@ func (p *dlnaPlayer) Toggle() {
 }
 
 func (p *dlnaPlayer) Seek(duration time.Duration) {
-	if p.controlURL == "" {
-		return
-	}
 	seekTime := formatDuration(duration)
 	if err := p.soapRequest("AVTransport", "Seek", fmt.Sprintf(seekBody, seekTime)); err != nil {
 		slog.Debug("DLNA: Seek not supported", "error", err)

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -242,7 +242,11 @@ func (p *dlnaPlayer) doSOAP(service, action, body string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Error("DLNA: failed to close response body", "error", err)
+		}
+	}()
 
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("soap request failed: %d", resp.StatusCode)

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -31,16 +32,42 @@ const playBody = `<u:Play xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
   <Speed>1</Speed>
 </u:Play>`
 
+const pauseBody = `<u:Pause xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+  <InstanceID>0</InstanceID>
+</u:Pause>`
+
+const stopBody = `<u:Stop xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+  <InstanceID>0</InstanceID>
+</u:Stop>`
+
+const seekBody = `<u:Seek xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+  <InstanceID>0</InstanceID>
+  <Unit>REL_TIME</Unit>
+  <Target>%s</Target>
+</u:Seek>`
+
+const getPositionInfoBody = `<u:GetPositionInfo xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+  <InstanceID>0</InstanceID>
+</u:GetPositionInfo>`
+
+const getTransportInfoBody = `<u:GetTransportInfo xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+  <InstanceID>0</InstanceID>
+</u:GetTransportInfo>`
+
 type dlnaPlayer struct {
 	deviceUrl  string
 	controlUrl string
 	audioUrl   string
+	audioDur   time.Duration
 	httpClient *http.Client
 	state      types.State
 	stateChan  chan types.State
 	musicChan  chan URLMusic
 	closed     chan struct{}
 	ready      chan struct{}
+
+	curPos   time.Duration
+	timeChan chan time.Duration
 }
 
 func NewDlnaPlayer(deviceUrl string) *dlnaPlayer {
@@ -52,6 +79,7 @@ func NewDlnaPlayer(deviceUrl string) *dlnaPlayer {
 		musicChan:  make(chan URLMusic, 10),
 		closed:     make(chan struct{}),
 		ready:      make(chan struct{}),
+		timeChan:   make(chan time.Duration, 1),
 	}
 	go p.initControlUrl()
 	return p
@@ -117,6 +145,76 @@ func (p *dlnaPlayer) initControlUrl() {
 	slog.Error("DLNA: AVTransport service not found")
 }
 
+func (p *dlnaPlayer) getPositionInfo() (time.Duration, time.Duration, error) {
+	body := getPositionInfoBody
+	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
+	req, err := http.NewRequest("POST", p.controlUrl, bytes.NewBufferString(envelope))
+	if err != nil {
+		return 0, 0, err
+	}
+	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
+	req.Header.Set("SOAPAction", `"urn:schemas-upnp-org:service:AVTransport:1#GetPositionInfo"`)
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return 0, 0, fmt.Errorf("GetPositionInfo failed: %d", resp.StatusCode)
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	type positionInfoResponse struct {
+		Track         string `xml:"Track"`
+		TrackDuration string `xml:"TrackDuration"`
+		RelTime       string `xml:"RelTime"`
+		AbsTime       string `xml:"AbsTime"`
+		RelCount      string `xml:"RelCount"`
+		AbsCount      string `xml:"AbsCount"`
+	}
+
+	type envelopeResponse struct {
+		Body struct {
+			GetPositionInfoResponse positionInfoResponse `xml:"GetPositionInfoResponse"`
+		} `xml:"Body"`
+	}
+
+	var env envelopeResponse
+	if err := xml.Unmarshal(respBody, &env); err != nil {
+		slog.Debug("DLNA: failed to parse position info", "error", err, "body", string(respBody))
+		return 0, 0, err
+	}
+
+	curPos := parseTime(env.Body.GetPositionInfoResponse.RelTime)
+	totalDur := parseTime(env.Body.GetPositionInfoResponse.TrackDuration)
+
+	slog.Debug("DLNA: position info", "relTime", env.Body.GetPositionInfoResponse.RelTime, "trackDuration", env.Body.GetPositionInfoResponse.TrackDuration, "parsedCurPos", curPos, "parsedTotal", totalDur)
+
+	return curPos, totalDur, nil
+}
+
+func parseTime(t string) time.Duration {
+	if t == "" || t == "NOT_IMPLEMENTED" {
+		return 0
+	}
+	parts := strings.Split(t, ":")
+	if len(parts) != 3 {
+		return 0
+	}
+	h, _ := strconv.Atoi(parts[0])
+	m, _ := strconv.Atoi(parts[1])
+	f := strings.Split(parts[2], ".")
+	s, _ := strconv.Atoi(f[0])
+	var ms int
+	if len(f) > 1 {
+		ms, _ = strconv.Atoi(f[1])
+	}
+	return time.Duration(h)*time.Hour + time.Duration(m)*time.Minute + time.Duration(s)*time.Second + time.Duration(ms)*time.Millisecond
+}
+
 func (p *dlnaPlayer) soapRequest(action, body string) error {
 	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
 	req, err := http.NewRequest("POST", p.controlUrl, bytes.NewBufferString(envelope))
@@ -145,6 +243,7 @@ func (p *dlnaPlayer) soapRequest(action, body string) error {
 
 func (p *dlnaPlayer) Play(music URLMusic) {
 	p.audioUrl = music.URL
+	p.audioDur = music.Duration
 	p.musicChan <- music
 
 	select {
@@ -173,23 +272,71 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 
 	p.state = types.Playing
 	p.stateChan <- p.state
+
+	go p.pollPositionInfo()
+}
+
+func (p *dlnaPlayer) pollPositionInfo() {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			curPos, _, err := p.getPositionInfo()
+			if err == nil && curPos > 0 {
+				p.curPos = curPos
+				select {
+				case p.timeChan <- curPos:
+				default:
+				}
+			}
+		case <-p.closed:
+			return
+		}
+	}
 }
 
 func (p *dlnaPlayer) CurMusic() URLMusic {
-	return URLMusic{URL: p.audioUrl}
+	music := URLMusic{
+		URL: p.audioUrl,
+	}
+	music.Duration = p.audioDur
+	return music
 }
 
 func (p *dlnaPlayer) Pause() {
+	if p.controlUrl == "" {
+		return
+	}
+	if err := p.soapRequest("Pause", pauseBody); err != nil {
+		slog.Error("DLNA: Pause failed", "error", err)
+		return
+	}
 	p.state = types.Paused
 	p.stateChan <- p.state
 }
 
 func (p *dlnaPlayer) Resume() {
+	if p.controlUrl == "" {
+		return
+	}
+	if err := p.soapRequest("Play", playBody); err != nil {
+		slog.Error("DLNA: Resume failed", "error", err)
+		return
+	}
 	p.state = types.Playing
 	p.stateChan <- p.state
 }
 
 func (p *dlnaPlayer) Stop() {
+	if p.controlUrl == "" {
+		return
+	}
+	if err := p.soapRequest("Stop", stopBody); err != nil {
+		slog.Error("DLNA: Stop failed", "error", err)
+		return
+	}
+	p.curPos = 0
 	p.state = types.Stopped
 	p.stateChan <- p.state
 }
@@ -202,14 +349,24 @@ func (p *dlnaPlayer) Toggle() {
 	}
 }
 
-func (p *dlnaPlayer) Seek(duration time.Duration) {}
+func (p *dlnaPlayer) Seek(duration time.Duration) {
+	if p.controlUrl == "" {
+		return
+	}
+	seekTime := formatDuration(duration)
+	if err := p.soapRequest("Seek", fmt.Sprintf(seekBody, seekTime)); err != nil {
+		slog.Debug("DLNA: Seek not supported", "error", err)
+	}
+}
 
-func (p *dlnaPlayer) PassedTime() time.Duration { return 0 }
+func (p *dlnaPlayer) PassedTime() time.Duration {
+	return p.curPos
+}
 
 func (p *dlnaPlayer) PlayedTime() time.Duration { return 0 }
 
 func (p *dlnaPlayer) TimeChan() <-chan time.Duration {
-	return make(chan time.Duration)
+	return p.timeChan
 }
 
 func (p *dlnaPlayer) State() types.State { return p.state }
@@ -226,4 +383,12 @@ func (p *dlnaPlayer) DownVolume() {}
 
 func (p *dlnaPlayer) Close() {
 	close(p.closed)
+}
+
+func formatDuration(d time.Duration) string {
+	totalSeconds := d.Seconds()
+	hours := int(totalSeconds) / 3600
+	minutes := (int(totalSeconds) % 3600) / 60
+	seconds := totalSeconds - float64(hours*3600+minutes*60)
+	return fmt.Sprintf("%02d:%02d:%06.3f", hours, minutes, seconds)
 }

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -1,3 +1,5 @@
+// Package player provides DLNA (Digital Living Network Alliance) player implementation
+// for streaming audio to DLNA-compatible devices.
 package player
 
 import (
@@ -25,7 +27,7 @@ const soapEnvelopeTpl = `<?xml version="1.0"?>
   </s:Body>
 </s:Envelope>`
 
-const setAvTransportUriBody = `<u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+const setAvTransportURIBody = `<u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
   <InstanceID>0</InstanceID>
   <CurrentURI>%s</CurrentURI>
   <CurrentURIMetaData></CurrentURIMetaData>
@@ -70,10 +72,10 @@ const setVolumeBody = `<u:SetVolume xmlns:u="urn:schemas-upnp-org:service:Render
 </u:SetVolume>`
 
 type dlnaPlayer struct {
-	deviceUrl           string
-	controlUrl          string
-	renderingControlUrl string
-	audioUrl            string
+	deviceURL           string
+	controlURL          string
+	renderingControlURL string
+	audioURL            string
 	audioDur            time.Duration
 	httpClient          *http.Client
 	state               types.State
@@ -92,9 +94,9 @@ type dlnaPlayer struct {
 	fileMapMu  sync.RWMutex
 }
 
-func NewDlnaPlayer(deviceUrl, localIP string) *dlnaPlayer {
+func NewDlnaPlayer(deviceURL, localIP string) *dlnaPlayer {
 	p := &dlnaPlayer{
-		deviceUrl:  deviceUrl,
+		deviceURL:  deviceURL,
 		localIP:    localIP,
 		httpClient: &http.Client{Timeout: 10 * time.Second},
 		state:      types.Stopped,
@@ -106,7 +108,7 @@ func NewDlnaPlayer(deviceUrl, localIP string) *dlnaPlayer {
 		fileMap:    make(map[int64]string),
 	}
 	p.startHTTPServer()
-	go p.initControlUrl()
+	go p.initControlURL()
 	return p
 }
 
@@ -125,16 +127,20 @@ type dlnaService struct {
 	ControlURL  string `xml:"controlURL"`
 }
 
-func (p *dlnaPlayer) initControlUrl() {
+func (p *dlnaPlayer) initControlURL() {
 	defer close(p.ready)
 
-	slog.Debug("DLNA: fetching device description", "url", p.deviceUrl)
-	resp, err := p.httpClient.Get(p.deviceUrl)
+	slog.Debug("DLNA: fetching device description", "url", p.deviceURL)
+	resp, err := p.httpClient.Get(p.deviceURL)
 	if err != nil {
 		slog.Error("DLNA: failed to fetch device description", "error", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Error("DLNA: failed to close response body", "error", err)
+		}
+	}()
 	xmlData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		slog.Error("DLNA: failed to read device description", "error", err)
@@ -150,35 +156,35 @@ func (p *dlnaPlayer) initControlUrl() {
 
 	base := r.URLBase
 	if base == "" {
-		base = p.deviceUrl[:len(p.deviceUrl)-len("/description.xml")] + "/"
+		base = p.deviceURL[:len(p.deviceURL)-len("/description.xml")] + "/"
 	}
 	base = strings.TrimRight(base, "/")
 	slog.Debug("DLNA: using base URL", "base", base)
 
 	for _, svc := range r.Device.Services {
-		slog.Debug("DLNA: found service", "type", svc.ServiceType, "controlUrl", svc.ControlURL)
+		slog.Debug("DLNA: found service", "type", svc.ServiceType, "controlURL", svc.ControlURL)
 		switch svc.ServiceType {
 		case "urn:schemas-upnp-org:service:AVTransport:1":
-			controlUrl := svc.ControlURL
-			if controlUrl != "" && !bytes.HasPrefix([]byte(controlUrl), []byte("http")) {
-				controlUrl = base + controlUrl
+			controlURL := svc.ControlURL
+			if controlURL != "" && !bytes.HasPrefix([]byte(controlURL), []byte("http")) {
+				controlURL = base + controlURL
 			}
-			p.controlUrl = controlUrl
-			slog.Info("DLNA: found AVTransport control URL", "url", controlUrl)
+			p.controlURL = controlURL
+			slog.Info("DLNA: found AVTransport control URL", "url", controlURL)
 		case "urn:schemas-upnp-org:service:RenderingControl:1":
-			controlUrl := svc.ControlURL
-			if controlUrl != "" && !bytes.HasPrefix([]byte(controlUrl), []byte("http")) {
-				controlUrl = base + controlUrl
+			controlURL := svc.ControlURL
+			if controlURL != "" && !bytes.HasPrefix([]byte(controlURL), []byte("http")) {
+				controlURL = base + controlURL
 			}
-			p.renderingControlUrl = controlUrl
-			slog.Info("DLNA: found RenderingControl control URL", "url", controlUrl)
+			p.renderingControlURL = controlURL
+			slog.Info("DLNA: found RenderingControl control URL", "url", controlURL)
 		}
 	}
 
-	if p.controlUrl == "" {
+	if p.controlURL == "" {
 		slog.Error("DLNA: AVTransport service not found")
 	}
-	if p.renderingControlUrl == "" {
+	if p.renderingControlURL == "" {
 		slog.Error("DLNA: RenderingControl service not found")
 	}
 
@@ -223,7 +229,7 @@ func (p *dlnaPlayer) serveLocalFile(w http.ResponseWriter, r *http.Request) {
 func (p *dlnaPlayer) getPositionInfo() (time.Duration, time.Duration, error) {
 	body := getPositionInfoBody
 	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
-	req, err := http.NewRequest("POST", p.controlUrl, bytes.NewBufferString(envelope))
+	req, err := http.NewRequest("POST", p.controlURL, bytes.NewBufferString(envelope))
 	if err != nil {
 		return 0, 0, err
 	}
@@ -234,7 +240,11 @@ func (p *dlnaPlayer) getPositionInfo() (time.Duration, time.Duration, error) {
 	if err != nil {
 		return 0, 0, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Error("DLNA: failed to close response body", "error", err)
+		}
+	}()
 
 	if resp.StatusCode >= 400 {
 		return 0, 0, fmt.Errorf("GetPositionInfo failed: %d", resp.StatusCode)
@@ -292,32 +302,36 @@ func parseTime(t string) time.Duration {
 
 func (p *dlnaPlayer) soapRequest(service, action, body string) error {
 	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
-	var controlUrl string
+	var controlURL string
 	switch service {
 	case "AVTransport":
-		controlUrl = p.controlUrl
+		controlURL = p.controlURL
 	case "RenderingControl":
-		controlUrl = p.renderingControlUrl
+		controlURL = p.renderingControlURL
 	default:
 		return fmt.Errorf("unknown service: %s", service)
 	}
-	if controlUrl == "" {
+	if controlURL == "" {
 		return fmt.Errorf("control URL for service %s not available", service)
 	}
-	req, err := http.NewRequest("POST", controlUrl, bytes.NewBufferString(envelope))
+	req, err := http.NewRequest("POST", controlURL, bytes.NewBufferString(envelope))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
 	req.Header.Set("SOAPAction", fmt.Sprintf(`"urn:schemas-upnp-org:service:%s:1#%s"`, service, action))
 
-	slog.Debug("DLNA: SOAP request", "action", action, "url", controlUrl)
+	slog.Debug("DLNA: SOAP request", "action", action, "url", controlURL)
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		slog.Error("DLNA: SOAP request failed", "action", action, "error", err)
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Error("DLNA: failed to close response body", "error", err)
+		}
+	}()
 
 	respBody, _ := io.ReadAll(resp.Body)
 	slog.Debug("DLNA: SOAP response", "action", action, "status", resp.StatusCode, "body", string(respBody))
@@ -375,7 +389,7 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 		slog.Debug("DLNA: converted file URL", "original", music.URL, "converted", audioURL)
 	}
 
-	p.audioUrl = audioURL
+	p.audioURL = audioURL
 	p.audioDur = music.Duration
 	p.musicChan <- music
 
@@ -386,13 +400,13 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 		return
 	}
 
-	if p.controlUrl == "" {
+	if p.controlURL == "" {
 		slog.Error("DLNA: control URL not found")
 		return
 	}
 
-	slog.Info("DLNA: setting AVTransport URI", "audioUrl", p.audioUrl)
-	if err := p.soapRequest("AVTransport", "SetAVTransportURI", fmt.Sprintf(setAvTransportUriBody, p.audioUrl)); err != nil {
+	slog.Info("DLNA: setting AVTransport URI", "audioURL", p.audioURL)
+	if err := p.soapRequest("AVTransport", "SetAVTransportURI", fmt.Sprintf(setAvTransportURIBody, p.audioURL)); err != nil {
 		slog.Error("DLNA: SetAVTransportURI failed", "error", err)
 		return
 	}
@@ -441,7 +455,7 @@ func (p *dlnaPlayer) pollPositionInfo() {
 
 func (p *dlnaPlayer) getTransportInfo() (string, error) {
 	envelope := fmt.Sprintf(soapEnvelopeTpl, getTransportInfoBody)
-	req, err := http.NewRequest("POST", p.controlUrl, bytes.NewBufferString(envelope))
+	req, err := http.NewRequest("POST", p.controlURL, bytes.NewBufferString(envelope))
 	if err != nil {
 		return "", err
 	}
@@ -452,7 +466,11 @@ func (p *dlnaPlayer) getTransportInfo() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Error("DLNA: failed to close response body", "error", err)
+		}
+	}()
 
 	if resp.StatusCode >= 400 {
 		return "", fmt.Errorf("GetTransportInfo failed: %d", resp.StatusCode)
@@ -480,14 +498,14 @@ func (p *dlnaPlayer) getTransportInfo() (string, error) {
 
 func (p *dlnaPlayer) CurMusic() URLMusic {
 	music := URLMusic{
-		URL: p.audioUrl,
+		URL: p.audioURL,
 	}
 	music.Duration = p.audioDur
 	return music
 }
 
 func (p *dlnaPlayer) Pause() {
-	if p.controlUrl == "" {
+	if p.controlURL == "" {
 		return
 	}
 	if err := p.soapRequest("AVTransport", "Pause", pauseBody); err != nil {
@@ -499,7 +517,7 @@ func (p *dlnaPlayer) Pause() {
 }
 
 func (p *dlnaPlayer) Resume() {
-	if p.controlUrl == "" {
+	if p.controlURL == "" {
 		return
 	}
 	if err := p.soapRequest("AVTransport", "Play", playBody); err != nil {
@@ -511,7 +529,7 @@ func (p *dlnaPlayer) Resume() {
 }
 
 func (p *dlnaPlayer) Stop() {
-	if p.controlUrl == "" {
+	if p.controlURL == "" {
 		return
 	}
 	if err := p.soapRequest("AVTransport", "Stop", stopBody); err != nil {
@@ -532,7 +550,7 @@ func (p *dlnaPlayer) Toggle() {
 }
 
 func (p *dlnaPlayer) Seek(duration time.Duration) {
-	if p.controlUrl == "" {
+	if p.controlURL == "" {
 		return
 	}
 	seekTime := formatDuration(duration)
@@ -556,12 +574,12 @@ func (p *dlnaPlayer) State() types.State { return p.state }
 func (p *dlnaPlayer) StateChan() <-chan types.State { return p.stateChan }
 
 func (p *dlnaPlayer) getVolume() (int, error) {
-	if p.renderingControlUrl == "" {
+	if p.renderingControlURL == "" {
 		return 0, errors.New("RenderingControl service not available")
 	}
 	body := getVolumeBody
 	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
-	req, err := http.NewRequest("POST", p.renderingControlUrl, bytes.NewBufferString(envelope))
+	req, err := http.NewRequest("POST", p.renderingControlURL, bytes.NewBufferString(envelope))
 	if err != nil {
 		return 0, err
 	}
@@ -572,7 +590,11 @@ func (p *dlnaPlayer) getVolume() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Error("DLNA: failed to close response body", "error", err)
+		}
+	}()
 
 	if resp.StatusCode >= 400 {
 		return 0, fmt.Errorf("GetVolume failed: %d", resp.StatusCode)
@@ -601,12 +623,12 @@ func (p *dlnaPlayer) getVolume() (int, error) {
 }
 
 func (p *dlnaPlayer) setVolume(volume int) error {
-	if p.renderingControlUrl == "" {
+	if p.renderingControlURL == "" {
 		return errors.New("RenderingControl service not available")
 	}
 	body := fmt.Sprintf(setVolumeBody, volume)
 	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
-	req, err := http.NewRequest("POST", p.renderingControlUrl, bytes.NewBufferString(envelope))
+	req, err := http.NewRequest("POST", p.renderingControlURL, bytes.NewBufferString(envelope))
 	if err != nil {
 		return err
 	}
@@ -617,7 +639,11 @@ func (p *dlnaPlayer) setVolume(volume int) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Error("DLNA: failed to close response body", "error", err)
+		}
+	}()
 
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("SetVolume failed: %d", resp.StatusCode)
@@ -664,7 +690,9 @@ func (p *dlnaPlayer) DownVolume() {
 func (p *dlnaPlayer) Close() {
 	close(p.closed)
 	if p.httpServer != nil {
-		p.httpServer.Close()
+		if err := p.httpServer.Close(); err != nil {
+			slog.Error("DLNA: failed to close HTTP server", "error", err)
+		}
 	}
 }
 

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -68,6 +68,8 @@ type dlnaPlayer struct {
 
 	curPos   time.Duration
 	timeChan chan time.Duration
+
+	polling bool
 }
 
 func NewDlnaPlayer(deviceUrl string) *dlnaPlayer {
@@ -273,7 +275,10 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 	p.state = types.Playing
 	p.stateChan <- p.state
 
-	go p.pollPositionInfo()
+	if !p.polling {
+		p.polling = true
+		go p.pollPositionInfo()
+	}
 }
 
 func (p *dlnaPlayer) pollPositionInfo() {
@@ -282,8 +287,14 @@ func (p *dlnaPlayer) pollPositionInfo() {
 	for {
 		select {
 		case <-ticker.C:
-			curPos, _, err := p.getPositionInfo()
-			if err == nil && curPos > 0 {
+			state, _ := p.getTransportInfo()
+			if state == "STOPPED" || state == "NO_MEDIA_PRESENT" {
+				p.state = types.Stopped
+				p.stateChan <- p.state
+				continue
+			}
+			curPos, _, _ := p.getPositionInfo()
+			if curPos > 0 {
 				p.curPos = curPos
 				select {
 				case p.timeChan <- curPos:
@@ -294,6 +305,45 @@ func (p *dlnaPlayer) pollPositionInfo() {
 			return
 		}
 	}
+}
+
+func (p *dlnaPlayer) getTransportInfo() (string, error) {
+	envelope := fmt.Sprintf(soapEnvelopeTpl, getTransportInfoBody)
+	req, err := http.NewRequest("POST", p.controlUrl, bytes.NewBufferString(envelope))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
+	req.Header.Set("SOAPAction", `"urn:schemas-upnp-org:service:AVTransport:1#GetTransportInfo"`)
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("GetTransportInfo failed: %d", resp.StatusCode)
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	type transportInfoResponse struct {
+		CurrentTransportState string `xml:"CurrentTransportState"`
+	}
+
+	type envelopeResponse struct {
+		Body struct {
+			GetTransportInfoResponse transportInfoResponse `xml:"GetTransportInfoResponse"`
+		} `xml:"Body"`
+	}
+
+	var env envelopeResponse
+	if err := xml.Unmarshal(respBody, &env); err != nil {
+		return "", err
+	}
+
+	return env.Body.GetTransportInfoResponse.CurrentTransportState, nil
 }
 
 func (p *dlnaPlayer) CurMusic() URLMusic {

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -11,7 +11,6 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -97,6 +96,8 @@ type dlnaPlayer struct {
 	pausedTime    time.Duration
 	pauseStart    time.Time
 	wasEverPlayed bool
+
+	cachedVolume int
 }
 
 func NewDlnaPlayer(deviceURL, localIP string) *dlnaPlayer {
@@ -187,7 +188,7 @@ func (p *dlnaPlayer) initControlURL() {
 	}
 
 	// 初始化完成後啟動輪詢，保持連接活躍
-	go p.pollPositionInfo()
+	go p.pollState()
 }
 
 func (p *dlnaPlayer) startHTTPServer() {
@@ -342,31 +343,6 @@ func (p *dlnaPlayer) soapRequest(service, action, body string) error {
 	return nil
 }
 
-func isFileReady(path string) bool {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	if fi.Size() == 0 {
-		return false
-	}
-	f, err := os.Open(path)
-	if err != nil {
-		return false
-	}
-	_ = f.Close()
-	return true
-}
-
-func (p *dlnaPlayer) waitForFileReady(path string) {
-	for i := 0; i < 10; i++ {
-		if isFileReady(path) {
-			return
-		}
-		time.Sleep(3 * time.Second)
-	}
-}
-
 func (p *dlnaPlayer) Play(music URLMusic) {
 	// 清理 fileMap，避免内存泄漏
 	p.fileMapMu.Lock()
@@ -377,11 +353,6 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 
 	if strings.HasPrefix(audioURL, "file://") {
 		localPath := strings.TrimPrefix(audioURL, "file://")
-		p.waitForFileReady(localPath)
-		if !isFileReady(localPath) {
-			slog.Error("DLNA: cache file not ready", "path", localPath)
-			return
-		}
 		p.fileMapMu.Lock()
 		p.fileMap[music.Id] = localPath
 		p.fileMapMu.Unlock()
@@ -421,13 +392,12 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 	p.wasEverPlayed = true
 }
 
-func (p *dlnaPlayer) pollPositionInfo() {
+func (p *dlnaPlayer) pollState() {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			// 保持連接活躍：DLNA 設備空閒會關閉連接，需持續輪詢避免
 			state, _ := p.getTransportInfo()
 			if state == "STOPPED" || state == "NO_MEDIA_PRESENT" {
 				p.state = types.Stopped
@@ -441,6 +411,9 @@ func (p *dlnaPlayer) pollPositionInfo() {
 				case p.timeChan <- curPos:
 				default:
 				}
+			}
+			if vol, err := p.getVolume(); err == nil {
+				p.cachedVolume = vol
 			}
 		case <-p.closed:
 			return
@@ -625,12 +598,7 @@ func (p *dlnaPlayer) setVolume(volume int) error {
 }
 
 func (p *dlnaPlayer) Volume() int {
-	vol, err := p.getVolume()
-	if err != nil {
-		slog.Debug("DLNA: failed to get volume", "error", err)
-		return 0
-	}
-	return vol
+	return p.cachedVolume
 }
 
 func (p *dlnaPlayer) SetVolume(volume int) {
@@ -642,7 +610,9 @@ func (p *dlnaPlayer) SetVolume(volume int) {
 	}
 	if err := p.setVolume(volume); err != nil {
 		slog.Error("DLNA: SetVolume failed", "error", err)
+		return
 	}
+	p.cachedVolume = volume
 }
 
 func (p *dlnaPlayer) UpVolume() {

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -187,7 +187,7 @@ func (p *dlnaPlayer) initControlURL() {
 		slog.Error("DLNA: RenderingControl service not found")
 	}
 
-	// 初始化完成後啟動輪詢，保持連接活躍
+	// Start polling after initialization to keep connection alive
 	go p.pollState()
 }
 
@@ -275,7 +275,7 @@ func (p *dlnaPlayer) getPositionInfo() (time.Duration, time.Duration, error) {
 	}
 
 	parse := func(t string) time.Duration {
-		if t == "" || t == "NOT_IMPLEMENTED" {
+		if t == "" || strings.HasPrefix(t, "NOT_IMPLEMENTED") {
 			return 0
 		}
 		parts := strings.Split(t, ":")
@@ -308,9 +308,11 @@ func (p *dlnaPlayer) sendState() {
 }
 
 func (p *dlnaPlayer) Play(music URLMusic) {
-	// 清理 fileMap，避免内存泄漏
+	// Clear fileMap to avoid memory leak
 	p.fileMapMu.Lock()
-	p.fileMap = make(map[int64]string)
+	for k := range p.fileMap {
+		delete(p.fileMap, k)
+	}
 	p.fileMapMu.Unlock()
 
 	audioURL := music.URL
@@ -522,12 +524,14 @@ func (p *dlnaPlayer) Volume() int {
 }
 
 func (p *dlnaPlayer) SetVolume(volume int) {
-	body := fmt.Sprintf(setVolumeBody, volume)
-	if _, err := p.doSOAP("RenderingControl", "SetVolume", body); err != nil {
-		slog.Error("DLNA: SetVolume failed", "error", err)
-		return
+	if volume >= 0 && volume <= 100 && volume != p.cachedVolume {
+		body := fmt.Sprintf(setVolumeBody, volume)
+		if _, err := p.doSOAP("RenderingControl", "SetVolume", body); err != nil {
+			slog.Error("DLNA: SetVolume failed", "error", err)
+			return
+		}
+		p.cachedVolume = volume
 	}
-	p.cachedVolume = volume
 }
 
 func (p *dlnaPlayer) UpVolume() {

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -103,7 +103,7 @@ func NewDlnaPlayer(deviceURL, localIP string) *dlnaPlayer {
 	p := &dlnaPlayer{
 		deviceURL:  deviceURL,
 		localIP:    localIP,
-		httpClient: &http.Client{Timeout: 10 * time.Second},
+		httpClient: &http.Client{Timeout: 1 * time.Second},
 		state:      types.Stopped,
 		stateChan:  make(chan types.State, 10),
 		musicChan:  make(chan URLMusic, 10),
@@ -191,9 +191,6 @@ func (p *dlnaPlayer) initControlURL() {
 }
 
 func (p *dlnaPlayer) startHTTPServer() {
-	if p.localIP == "" {
-		panic("DLNA: localIP is required in config [player.dlna].localIP")
-	}
 	for i := 0; i < 10; i++ {
 		listener, err := net.Listen("tcp", p.localIP+":0")
 		if err != nil {
@@ -407,11 +404,6 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 	if err := p.soapRequest("AVTransport", "SetAVTransportURI", fmt.Sprintf(setAvTransportURIBody, p.audioURL)); err != nil {
 		slog.Error("DLNA: SetAVTransportURI failed", "error", err)
 		return
-	}
-
-	// 同步获取当前位置，确保 PassedTime() 立即准确
-	if curPos, _, err := p.getPositionInfo(); err == nil {
-		p.curPos = curPos
 	}
 
 	slog.Info("DLNA: starting playback")

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -222,125 +222,76 @@ func (p *dlnaPlayer) serveLocalFile(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, path)
 }
 
-func (p *dlnaPlayer) executeSOAPRequest(controlURL, action, body string) ([]byte, error) {
+func (p *dlnaPlayer) doSOAP(service, action, body string) ([]byte, error) {
+	controlURL := p.controlURL
+	if service == "RenderingControl" {
+		controlURL = p.renderingControlURL
+		if controlURL == "" {
+			return nil, errors.New("RenderingControl service not available")
+		}
+	}
 	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
 	req, err := http.NewRequest("POST", controlURL, bytes.NewBufferString(envelope))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
-	req.Header.Set("SOAPAction", fmt.Sprintf(`"urn:schemas-upnp-org:service:%s"`, action))
+	req.Header.Set("SOAPAction", fmt.Sprintf(`"urn:schemas-upnp-org:service:%s:1#%s"`, service, action))
 
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			slog.Error("DLNA: failed to close response body", "error", err)
-		}
-	}()
+	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("%s failed: %d", action, resp.StatusCode)
+		return nil, fmt.Errorf("soap request failed: %d", resp.StatusCode)
 	}
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	return respBody, nil
+	return io.ReadAll(resp.Body)
 }
 
 func (p *dlnaPlayer) getPositionInfo() (time.Duration, time.Duration, error) {
-	respBody, err := p.executeSOAPRequest(p.controlURL, "AVTransport:1#GetPositionInfo", getPositionInfoBody)
+	respBody, err := p.doSOAP("AVTransport", "GetPositionInfo", getPositionInfoBody)
 	if err != nil {
 		return 0, 0, err
 	}
 
-	type positionInfoResponse struct {
-		Track         string `xml:"Track"`
-		TrackDuration string `xml:"TrackDuration"`
-		RelTime       string `xml:"RelTime"`
-		AbsTime       string `xml:"AbsTime"`
-		RelCount      string `xml:"RelCount"`
-		AbsCount      string `xml:"AbsCount"`
-	}
-
 	type envelopeResponse struct {
 		Body struct {
-			GetPositionInfoResponse positionInfoResponse `xml:"GetPositionInfoResponse"`
+			GetPositionInfoResponse struct {
+				TrackDuration string `xml:"TrackDuration"`
+				RelTime       string `xml:"RelTime"`
+			} `xml:"GetPositionInfoResponse"`
 		} `xml:"Body"`
 	}
 
 	var env envelopeResponse
 	if err := xml.Unmarshal(respBody, &env); err != nil {
-		slog.Debug("DLNA: failed to parse position info", "error", err, "body", string(respBody))
 		return 0, 0, err
 	}
 
-	curPos := parseTime(env.Body.GetPositionInfoResponse.RelTime)
-	totalDur := parseTime(env.Body.GetPositionInfoResponse.TrackDuration)
+	parse := func(t string) time.Duration {
+		if t == "" || t == "NOT_IMPLEMENTED" {
+			return 0
+		}
+		parts := strings.Split(t, ":")
+		if len(parts) != 3 {
+			return 0
+		}
+		h, _ := strconv.Atoi(parts[0])
+		m, _ := strconv.Atoi(parts[1])
+		f := strings.Split(parts[2], ".")
+		s, _ := strconv.Atoi(f[0])
+		var ms int
+		if len(f) > 1 {
+			ms, _ = strconv.Atoi(f[1])
+		}
+		return time.Duration(h)*time.Hour + time.Duration(m)*time.Minute + time.Duration(s)*time.Second + time.Duration(ms)*time.Millisecond
+	}
 
-	slog.Debug("DLNA: position info", "relTime", env.Body.GetPositionInfoResponse.RelTime, "trackDuration", env.Body.GetPositionInfoResponse.TrackDuration, "parsedCurPos", curPos, "parsedTotal", totalDur)
-
+	curPos := parse(env.Body.GetPositionInfoResponse.RelTime)
+	totalDur := parse(env.Body.GetPositionInfoResponse.TrackDuration)
 	return curPos, totalDur, nil
-}
-
-func parseTime(t string) time.Duration {
-	if t == "" || t == "NOT_IMPLEMENTED" {
-		return 0
-	}
-	parts := strings.Split(t, ":")
-	if len(parts) != 3 {
-		return 0
-	}
-	h, _ := strconv.Atoi(parts[0])
-	m, _ := strconv.Atoi(parts[1])
-	f := strings.Split(parts[2], ".")
-	s, _ := strconv.Atoi(f[0])
-	var ms int
-	if len(f) > 1 {
-		ms, _ = strconv.Atoi(f[1])
-	}
-	return time.Duration(h)*time.Hour + time.Duration(m)*time.Minute + time.Duration(s)*time.Second + time.Duration(ms)*time.Millisecond
-}
-
-func (p *dlnaPlayer) soapRequest(service, action, body string) error {
-	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
-	controlURL := p.controlURL
-	if service == "RenderingControl" {
-		controlURL = p.renderingControlURL
-		if controlURL == "" {
-			return fmt.Errorf("RenderingControl service not available")
-		}
-	}
-	req, err := http.NewRequest("POST", controlURL, bytes.NewBufferString(envelope))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
-	req.Header.Set("SOAPAction", fmt.Sprintf(`"urn:schemas-upnp-org:service:%s:1#%s"`, service, action))
-
-	slog.Debug("DLNA: SOAP request", "action", action, "url", controlURL)
-	resp, err := p.httpClient.Do(req)
-	if err != nil {
-		slog.Error("DLNA: SOAP request failed", "action", action, "error", err)
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			slog.Error("DLNA: failed to close response body", "error", err)
-		}
-	}()
-
-	respBody, _ := io.ReadAll(resp.Body)
-	slog.Debug("DLNA: SOAP response", "action", action, "status", resp.StatusCode, "body", string(respBody))
-
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("soap request failed: %d", resp.StatusCode)
-	}
-	return nil
 }
 
 func (p *dlnaPlayer) Play(music URLMusic) {
@@ -372,13 +323,13 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 	}
 
 	slog.Info("DLNA: setting AVTransport URI", "audioURL", p.audioURL)
-	if err := p.soapRequest("AVTransport", "SetAVTransportURI", fmt.Sprintf(setAvTransportURIBody, p.audioURL)); err != nil {
+	if _, err := p.doSOAP("AVTransport", "SetAVTransportURI", fmt.Sprintf(setAvTransportURIBody, p.audioURL)); err != nil {
 		slog.Error("DLNA: SetAVTransportURI failed", "error", err)
 		return
 	}
 
 	slog.Info("DLNA: starting playback")
-	if err := p.soapRequest("AVTransport", "Play", playBody); err != nil {
+	if _, err := p.doSOAP("AVTransport", "Play", playBody); err != nil {
 		slog.Error("DLNA: Play failed", "error", err)
 		return
 	}
@@ -422,18 +373,16 @@ func (p *dlnaPlayer) pollState() {
 }
 
 func (p *dlnaPlayer) getTransportInfo() (string, error) {
-	respBody, err := p.executeSOAPRequest(p.controlURL, "AVTransport:1#GetTransportInfo", getTransportInfoBody)
+	respBody, err := p.doSOAP("AVTransport", "GetTransportInfo", getTransportInfoBody)
 	if err != nil {
 		return "", err
 	}
 
-	type transportInfoResponse struct {
-		CurrentTransportState string `xml:"CurrentTransportState"`
-	}
-
 	type envelopeResponse struct {
 		Body struct {
-			GetTransportInfoResponse transportInfoResponse `xml:"GetTransportInfoResponse"`
+			GetTransportInfoResponse struct {
+				CurrentTransportState string `xml:"CurrentTransportState"`
+			} `xml:"GetTransportInfoResponse"`
 		} `xml:"Body"`
 	}
 
@@ -441,7 +390,6 @@ func (p *dlnaPlayer) getTransportInfo() (string, error) {
 	if err := xml.Unmarshal(respBody, &env); err != nil {
 		return "", err
 	}
-
 	return env.Body.GetTransportInfoResponse.CurrentTransportState, nil
 }
 
@@ -461,7 +409,7 @@ func (p *dlnaPlayer) CurMusic() URLMusic {
 }
 
 func (p *dlnaPlayer) Pause() {
-	if err := p.soapRequest("AVTransport", "Pause", pauseBody); err != nil {
+	if _, err := p.doSOAP("AVTransport", "Pause", pauseBody); err != nil {
 		slog.Error("DLNA: Pause failed", "error", err)
 		return
 	}
@@ -473,7 +421,7 @@ func (p *dlnaPlayer) Pause() {
 }
 
 func (p *dlnaPlayer) Resume() {
-	if err := p.soapRequest("AVTransport", "Play", playBody); err != nil {
+	if _, err := p.doSOAP("AVTransport", "Play", playBody); err != nil {
 		slog.Error("DLNA: Resume failed", "error", err)
 		return
 	}
@@ -485,7 +433,7 @@ func (p *dlnaPlayer) Resume() {
 }
 
 func (p *dlnaPlayer) Stop() {
-	if err := p.soapRequest("AVTransport", "Stop", stopBody); err != nil {
+	if _, err := p.doSOAP("AVTransport", "Stop", stopBody); err != nil {
 		slog.Error("DLNA: Stop failed", "error", err)
 		return
 	}
@@ -509,7 +457,7 @@ func (p *dlnaPlayer) Toggle() {
 
 func (p *dlnaPlayer) Seek(duration time.Duration) {
 	seekTime := formatDuration(duration)
-	if err := p.soapRequest("AVTransport", "Seek", fmt.Sprintf(seekBody, seekTime)); err != nil {
+	if _, err := p.doSOAP("AVTransport", "Seek", fmt.Sprintf(seekBody, seekTime)); err != nil {
 		slog.Debug("DLNA: Seek not supported", "error", err)
 	}
 }
@@ -533,57 +481,22 @@ func (p *dlnaPlayer) State() types.State { return p.state }
 
 func (p *dlnaPlayer) StateChan() <-chan types.State { return p.stateChan }
 
-func (p *dlnaPlayer) renderControlSOAPRequest(action, body string) (*http.Response, []byte, error) {
-	if p.renderingControlURL == "" {
-		return nil, nil, errors.New("RenderingControl service not available")
-	}
-	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
-	req, err := http.NewRequest("POST", p.renderingControlURL, bytes.NewBufferString(envelope))
-	if err != nil {
-		return nil, nil, err
-	}
-	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
-	req.Header.Set("SOAPAction", fmt.Sprintf(`"urn:schemas-upnp-org:service:RenderingControl:1#%s"`, action))
-
-	resp, err := p.httpClient.Do(req)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			slog.Error("DLNA: failed to close response body", "error", err)
-		}
-	}()
-
-	if resp.StatusCode >= 400 {
-		return nil, nil, fmt.Errorf("%s failed: %d", action, resp.StatusCode)
-	}
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, nil, err
-	}
-	return resp, respBody, nil
-}
-
 func (p *dlnaPlayer) getVolume() (int, error) {
-	_, respBody, err := p.renderControlSOAPRequest("GetVolume", getVolumeBody)
+	respBody, err := p.doSOAP("RenderingControl", "GetVolume", getVolumeBody)
 	if err != nil {
 		return 0, err
 	}
 
-	type volumeResponse struct {
-		CurrentVolume string `xml:"CurrentVolume"`
-	}
 	type envelopeResponse struct {
 		Body struct {
-			GetVolumeResponse volumeResponse `xml:"GetVolumeResponse"`
+			GetVolumeResponse struct {
+				CurrentVolume string `xml:"CurrentVolume"`
+			} `xml:"GetVolumeResponse"`
 		} `xml:"Body"`
 	}
 
 	var env envelopeResponse
 	if err := xml.Unmarshal(respBody, &env); err != nil {
-		slog.Debug("DLNA: failed to parse volume", "error", err, "body", string(respBody))
 		return 0, err
 	}
 
@@ -597,7 +510,7 @@ func (p *dlnaPlayer) Volume() int {
 
 func (p *dlnaPlayer) SetVolume(volume int) {
 	body := fmt.Sprintf(setVolumeBody, volume)
-	if err := p.soapRequest("RenderingControl", "SetVolume", body); err != nil {
+	if _, err := p.doSOAP("RenderingControl", "SetVolume", body); err != nil {
 		slog.Error("DLNA: SetVolume failed", "error", err)
 		return
 	}

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -100,7 +100,7 @@ type dlnaPlayer struct {
 	cachedVolume int
 }
 
-func NewDlnaPlayer(deviceURL, localIP string) *dlnaPlayer {
+func NewDlnaPlayer(deviceURL, localIP string) (Player, error) {
 	p := &dlnaPlayer{
 		deviceURL:  deviceURL,
 		localIP:    localIP,
@@ -113,9 +113,14 @@ func NewDlnaPlayer(deviceURL, localIP string) *dlnaPlayer {
 		timeChan:   make(chan time.Duration, 1),
 		fileMap:    make(map[int64]string),
 	}
-	p.startHTTPServer()
-	go p.initControlURL()
-	return p
+	if err := p.startHTTPServer(); err != nil {
+		return nil, err
+	}
+	if err := p.initControlURL(); err != nil {
+		p.Close()
+		return nil, err
+	}
+	return p, nil
 }
 
 type dlnaRoot struct {
@@ -133,14 +138,14 @@ type dlnaService struct {
 	ControlURL  string `xml:"controlURL"`
 }
 
-func (p *dlnaPlayer) initControlURL() {
+func (p *dlnaPlayer) initControlURL() error {
 	defer close(p.ready)
 
 	slog.Debug("DLNA: fetching device description", "url", p.deviceURL)
 	resp, err := p.httpClient.Get(p.deviceURL)
 	if err != nil {
 		slog.Error("DLNA: failed to fetch device description", "error", err)
-		return
+		return err
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -150,14 +155,14 @@ func (p *dlnaPlayer) initControlURL() {
 	xmlData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		slog.Error("DLNA: failed to read device description", "error", err)
-		return
+		return err
 	}
 
 	var r dlnaRoot
 	if err := xml.Unmarshal(xmlData, &r); err != nil {
 		slog.Error("DLNA: failed to parse device description", "error", err)
 		slog.Debug("DLNA: raw XML", "data", string(xmlData))
-		return
+		return err
 	}
 
 	base := r.URLBase
@@ -181,7 +186,7 @@ func (p *dlnaPlayer) initControlURL() {
 	}
 
 	if p.controlURL == "" {
-		panic("DLNA: AVTransport service not found or invalid")
+		return errors.New("DLNA: AVTransport service not found or invalid")
 	}
 	if p.renderingControlURL == "" {
 		slog.Error("DLNA: RenderingControl service not found")
@@ -189,9 +194,10 @@ func (p *dlnaPlayer) initControlURL() {
 
 	// Start polling after initialization to keep connection alive
 	go p.pollState()
+	return nil
 }
 
-func (p *dlnaPlayer) startHTTPServer() {
+func (p *dlnaPlayer) startHTTPServer() error {
 	for i := 0; i < 10; i++ {
 		listener, err := net.Listen("tcp", p.localIP+":0")
 		if err != nil {
@@ -208,9 +214,9 @@ func (p *dlnaPlayer) startHTTPServer() {
 			}
 		}()
 		slog.Info("DLNA: HTTP server started", "bind", p.localIP, "port", p.httpPort)
-		return
+		return nil
 	}
-	panic("DLNA: failed to start HTTP server after 10 attempts")
+	return errors.New("DLNA: failed to start HTTP server after 10 attempts")
 }
 
 func (p *dlnaPlayer) serveLocalFile(w http.ResponseWriter, r *http.Request) {

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -58,17 +58,29 @@ const getTransportInfoBody = `<u:GetTransportInfo xmlns:u="urn:schemas-upnp-org:
   <InstanceID>0</InstanceID>
 </u:GetTransportInfo>`
 
+const getVolumeBody = `<u:GetVolume xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1">
+  <InstanceID>0</InstanceID>
+  <Channel>Master</Channel>
+</u:GetVolume>`
+
+const setVolumeBody = `<u:SetVolume xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1">
+  <InstanceID>0</InstanceID>
+  <Channel>Master</Channel>
+  <DesiredVolume>%d</DesiredVolume>
+</u:SetVolume>`
+
 type dlnaPlayer struct {
-	deviceUrl  string
-	controlUrl string
-	audioUrl   string
-	audioDur   time.Duration
-	httpClient *http.Client
-	state      types.State
-	stateChan  chan types.State
-	musicChan  chan URLMusic
-	closed     chan struct{}
-	ready      chan struct{}
+	deviceUrl           string
+	controlUrl          string
+	renderingControlUrl string
+	audioUrl            string
+	audioDur            time.Duration
+	httpClient          *http.Client
+	state               types.State
+	stateChan           chan types.State
+	musicChan           chan URLMusic
+	closed              chan struct{}
+	ready               chan struct{}
 
 	curPos   time.Duration
 	timeChan chan time.Duration
@@ -147,17 +159,30 @@ func (p *dlnaPlayer) initControlUrl() {
 
 	for _, svc := range r.Device.Services {
 		slog.Debug("DLNA: found service", "type", svc.ServiceType, "controlUrl", svc.ControlURL)
-		if svc.ServiceType == "urn:schemas-upnp-org:service:AVTransport:1" {
+		switch svc.ServiceType {
+		case "urn:schemas-upnp-org:service:AVTransport:1":
 			controlUrl := svc.ControlURL
 			if controlUrl != "" && !bytes.HasPrefix([]byte(controlUrl), []byte("http")) {
 				controlUrl = base + controlUrl
 			}
 			p.controlUrl = controlUrl
 			slog.Info("DLNA: found AVTransport control URL", "url", controlUrl)
-			return
+		case "urn:schemas-upnp-org:service:RenderingControl:1":
+			controlUrl := svc.ControlURL
+			if controlUrl != "" && !bytes.HasPrefix([]byte(controlUrl), []byte("http")) {
+				controlUrl = base + controlUrl
+			}
+			p.renderingControlUrl = controlUrl
+			slog.Info("DLNA: found RenderingControl control URL", "url", controlUrl)
 		}
 	}
-	slog.Error("DLNA: AVTransport service not found")
+
+	if p.controlUrl == "" {
+		slog.Error("DLNA: AVTransport service not found")
+	}
+	if p.renderingControlUrl == "" {
+		slog.Error("DLNA: RenderingControl service not found")
+	}
 }
 
 func (p *dlnaPlayer) startHTTPServer() {
@@ -264,16 +289,28 @@ func parseTime(t string) time.Duration {
 	return time.Duration(h)*time.Hour + time.Duration(m)*time.Minute + time.Duration(s)*time.Second + time.Duration(ms)*time.Millisecond
 }
 
-func (p *dlnaPlayer) soapRequest(action, body string) error {
+func (p *dlnaPlayer) soapRequest(service, action, body string) error {
 	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
-	req, err := http.NewRequest("POST", p.controlUrl, bytes.NewBufferString(envelope))
+	var controlUrl string
+	switch service {
+	case "AVTransport":
+		controlUrl = p.controlUrl
+	case "RenderingControl":
+		controlUrl = p.renderingControlUrl
+	default:
+		return fmt.Errorf("unknown service: %s", service)
+	}
+	if controlUrl == "" {
+		return fmt.Errorf("control URL for service %s not available", service)
+	}
+	req, err := http.NewRequest("POST", controlUrl, bytes.NewBufferString(envelope))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
-	req.Header.Set("SOAPAction", fmt.Sprintf(`"urn:schemas-upnp-org:service:AVTransport:1#%s"`, action))
+	req.Header.Set("SOAPAction", fmt.Sprintf(`"urn:schemas-upnp-org:service:%s:1#%s"`, service, action))
 
-	slog.Debug("DLNA: SOAP request", "action", action, "url", p.controlUrl)
+	slog.Debug("DLNA: SOAP request", "action", action, "url", controlUrl)
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		slog.Error("DLNA: SOAP request failed", "action", action, "error", err)
@@ -354,13 +391,13 @@ func (p *dlnaPlayer) Play(music URLMusic) {
 	}
 
 	slog.Info("DLNA: setting AVTransport URI", "audioUrl", p.audioUrl)
-	if err := p.soapRequest("SetAVTransportURI", fmt.Sprintf(setAvTransportUriBody, p.audioUrl)); err != nil {
+	if err := p.soapRequest("AVTransport", "SetAVTransportURI", fmt.Sprintf(setAvTransportUriBody, p.audioUrl)); err != nil {
 		slog.Error("DLNA: SetAVTransportURI failed", "error", err)
 		return
 	}
 
 	slog.Info("DLNA: starting playback")
-	if err := p.soapRequest("Play", playBody); err != nil {
+	if err := p.soapRequest("AVTransport", "Play", playBody); err != nil {
 		slog.Error("DLNA: Play failed", "error", err)
 		return
 	}
@@ -455,7 +492,7 @@ func (p *dlnaPlayer) Pause() {
 	if p.controlUrl == "" {
 		return
 	}
-	if err := p.soapRequest("Pause", pauseBody); err != nil {
+	if err := p.soapRequest("AVTransport", "Pause", pauseBody); err != nil {
 		slog.Error("DLNA: Pause failed", "error", err)
 		return
 	}
@@ -470,7 +507,7 @@ func (p *dlnaPlayer) Resume() {
 	if p.controlUrl == "" {
 		return
 	}
-	if err := p.soapRequest("Play", playBody); err != nil {
+	if err := p.soapRequest("AVTransport", "Play", playBody); err != nil {
 		slog.Error("DLNA: Resume failed", "error", err)
 		return
 	}
@@ -482,7 +519,7 @@ func (p *dlnaPlayer) Stop() {
 	if p.controlUrl == "" {
 		return
 	}
-	if err := p.soapRequest("Stop", stopBody); err != nil {
+	if err := p.soapRequest("AVTransport", "Stop", stopBody); err != nil {
 		slog.Error("DLNA: Stop failed", "error", err)
 		return
 	}
@@ -507,7 +544,7 @@ func (p *dlnaPlayer) Seek(duration time.Duration) {
 		return
 	}
 	seekTime := formatDuration(duration)
-	if err := p.soapRequest("Seek", fmt.Sprintf(seekBody, seekTime)); err != nil {
+	if err := p.soapRequest("AVTransport", "Seek", fmt.Sprintf(seekBody, seekTime)); err != nil {
 		slog.Debug("DLNA: Seek not supported", "error", err)
 	}
 }
@@ -526,13 +563,111 @@ func (p *dlnaPlayer) State() types.State { return p.state }
 
 func (p *dlnaPlayer) StateChan() <-chan types.State { return p.stateChan }
 
-func (p *dlnaPlayer) Volume() int { return 0 }
+func (p *dlnaPlayer) getVolume() (int, error) {
+	if p.renderingControlUrl == "" {
+		return 0, errors.New("RenderingControl service not available")
+	}
+	body := getVolumeBody
+	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
+	req, err := http.NewRequest("POST", p.renderingControlUrl, bytes.NewBufferString(envelope))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
+	req.Header.Set("SOAPAction", `"urn:schemas-upnp-org:service:RenderingControl:1#GetVolume"`)
 
-func (p *dlnaPlayer) SetVolume(volume int) {}
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
 
-func (p *dlnaPlayer) UpVolume() {}
+	if resp.StatusCode >= 400 {
+		return 0, fmt.Errorf("GetVolume failed: %d", resp.StatusCode)
+	}
 
-func (p *dlnaPlayer) DownVolume() {}
+	respBody, _ := io.ReadAll(resp.Body)
+
+	type volumeResponse struct {
+		CurrentVolume string `xml:"CurrentVolume"`
+	}
+
+	type envelopeResponse struct {
+		Body struct {
+			GetVolumeResponse volumeResponse `xml:"GetVolumeResponse"`
+		} `xml:"Body"`
+	}
+
+	var env envelopeResponse
+	if err := xml.Unmarshal(respBody, &env); err != nil {
+		slog.Debug("DLNA: failed to parse volume", "error", err, "body", string(respBody))
+		return 0, err
+	}
+
+	volume, _ := strconv.Atoi(env.Body.GetVolumeResponse.CurrentVolume)
+	return volume, nil
+}
+
+func (p *dlnaPlayer) setVolume(volume int) error {
+	if p.renderingControlUrl == "" {
+		return errors.New("RenderingControl service not available")
+	}
+	body := fmt.Sprintf(setVolumeBody, volume)
+	envelope := fmt.Sprintf(soapEnvelopeTpl, body)
+	req, err := http.NewRequest("POST", p.renderingControlUrl, bytes.NewBufferString(envelope))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
+	req.Header.Set("SOAPAction", `"urn:schemas-upnp-org:service:RenderingControl:1#SetVolume"`)
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("SetVolume failed: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (p *dlnaPlayer) Volume() int {
+	vol, err := p.getVolume()
+	if err != nil {
+		slog.Debug("DLNA: failed to get volume", "error", err)
+		return 0
+	}
+	return vol
+}
+
+func (p *dlnaPlayer) SetVolume(volume int) {
+	if volume < 0 {
+		volume = 0
+	}
+	if volume > 100 {
+		volume = 100
+	}
+	if err := p.setVolume(volume); err != nil {
+		slog.Error("DLNA: SetVolume failed", "error", err)
+	}
+}
+
+func (p *dlnaPlayer) UpVolume() {
+	current := p.Volume()
+	if current < 100 {
+		p.SetVolume(current + 1)
+	}
+}
+
+func (p *dlnaPlayer) DownVolume() {
+	current := p.Volume()
+	if current > 0 {
+		p.SetVolume(current - 1)
+	}
+}
 
 func (p *dlnaPlayer) Close() {
 	close(p.closed)

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -33,6 +33,7 @@ type Player interface {
 func NewPlayerFromConfig() Player {
 	cfg := configs.AppConfig
 	var player Player
+	var err error
 	switch cfg.Player.Engine {
 	case types.BeepPlayer:
 		player = NewBeepPlayer()
@@ -72,7 +73,10 @@ func NewPlayerFromConfig() Player {
 		if cfg.Player.Dlna.LocalIP == "" {
 			panic("缺少DLNA配置: localIP (必须指定本机局域网IP)")
 		}
-		player = NewDlnaPlayer(cfg.Player.Dlna.DeviceUrl, cfg.Player.Dlna.LocalIP)
+		player, err = NewDlnaPlayer(cfg.Player.Dlna.DeviceUrl, cfg.Player.Dlna.LocalIP)
+		if err != nil {
+			panic(err)
+		}
 	default:
 		panic("unknown player engine")
 	}

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -63,8 +63,13 @@ func NewPlayerFromConfig() Player {
 			panic(fmt.Sprintf("MPV不可用: %v, 输出: %s", err, string(output)))
 		}
 		player = NewMpvPlayer(&MpvConfig{
-			BinPath: cfg.Player.Mpv.Bin, // 使用配置文件中的mpv路径
+			BinPath: cfg.Player.Mpv.Bin,
 		})
+	case types.DlnaPlayer:
+		if cfg.Player.Dlna.DeviceUrl == "" {
+			panic("缺少DLNA配置: deviceUrl")
+		}
+		player = NewDlnaPlayer(cfg.Player.Dlna.DeviceUrl)
 	default:
 		panic("unknown player engine")
 	}

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -69,7 +69,10 @@ func NewPlayerFromConfig() Player {
 		if cfg.Player.Dlna.DeviceUrl == "" {
 			panic("缺少DLNA配置: deviceUrl")
 		}
-		player = NewDlnaPlayer(cfg.Player.Dlna.DeviceUrl)
+		if cfg.Player.Dlna.LocalIP == "" {
+			panic("缺少DLNA配置: localIP (必须指定本机局域网IP)")
+		}
+		player = NewDlnaPlayer(cfg.Player.Dlna.DeviceUrl, cfg.Player.Dlna.LocalIP)
 	default:
 		panic("unknown player engine")
 	}

--- a/internal/types/constants.go
+++ b/internal/types/constants.go
@@ -44,6 +44,7 @@ const MpdPlayer = "mpd"            // mpd
 const MpvPlayer = "mpv"            // mpv player
 const OsxPlayer = "osx"            // osx
 const WinMediaPlayer = "win_media" // win media player
+const DlnaPlayer = "dlna"          // dlna
 
 const BeepGoMp3Decoder = "go-mp3"
 const BeepMiniMp3Decoder = "minimp3"

--- a/utils/filex/embed/config.toml
+++ b/utils/filex/embed/config.toml
@@ -148,7 +148,7 @@ limit = 0
 
 # 播放器引擎与行为配置
 [player]
-# 播放引擎，可选: "beep", "mpd", "mpv", "osx", "win_media", "auto"（根据系统自动选择）
+# 播放引擎，可选: "beep", "dlna", "mpd", "mpv", "osx", "win_media", "auto"（根据系统自动选择）
 # Mac 默认 "osx", Windows 默认 "win_media", 其他系统默认 "beep"
 engine = "auto"
 # 允许的最大连续失败重试次数
@@ -189,6 +189,14 @@ autoStart = true
 [player.mpv]
 # mpv 可执行文件的路径，如果为空，则在系统 PATH 中查找
 bin = "mpv"
+
+# `dlna` 引擎专属配置
+[player.dlna]
+# DLNA 设备描述 URL，例如：http://192.168.1.100:49152/description.xml
+# 使用 gupnp-tools 的 gupnp-universal-cp 工具可扫描并获取设备 URL
+deviceUrl = ""
+# 本机局域网 IP（用于内置 HTTP server）
+localIP = ""
 
 
 # 启动时自动播放相关配置


### PR DESCRIPTION
## 新增功能

添加 DLNA/UPnP 播放引擎支持，可以将音乐投送到网络播放设备。

## 主要变更

- 新增 DLNA 播放器实现，支持 UPnP/DLNA 设备发现和控制
- 为 file:// URL 自动启动内置 HTTP 服务器
- 实现音量控制和播放进度显示
- 修复播放时间跟踪、内存泄漏等问题

## 测试建议

- DLNA 设备上的播放测试
- 音量控制和进度跳转
- file:// 和 http:// URL 的处理