### PR TITLE
fix(mpris): 修复 Seeked 信号在正常播放时被持续错误发射

### DIFF
--- a/internal/remote_control/remote_control.go
+++ b/internal/remote_control/remote_control.go
@@ -14,6 +14,9 @@ func NewRemoteControl(Controller, PlayingInfo) *RemoteControl {
 func (s *RemoteControl) SetPosition(time.Duration) {
 }
 
+func (s *RemoteControl) EmitSeeked(time.Duration) {
+}
+
 func (s *RemoteControl) SetPlayingInfo(PlayingInfo) {
 }
 

--- a/internal/remote_control/remote_control_darwin.go
+++ b/internal/remote_control/remote_control_darwin.go
@@ -159,6 +159,9 @@ func (s *RemoteControl) SetPlayingInfo(info PlayingInfo) {
 func (s *RemoteControl) SetPosition(time.Duration) {
 }
 
+func (s *RemoteControl) EmitSeeked(time.Duration) {
+}
+
 func (s *RemoteControl) Release() {
 	s.nowPlayingCenter.Release()
 	s.remoteCommandCenter.Release()

--- a/internal/remote_control/remote_control_linux.go
+++ b/internal/remote_control/remote_control_linux.go
@@ -305,10 +305,15 @@ func (s *RemoteControl) SetPosition(duration time.Duration) {
 
 	position := UsFromDuration(duration)
 	_ = s.props.Set("org.mpris.MediaPlayer2.Player", "Position", dbus.MakeVariant(position))
+}
 
-	if s.dbus != nil {
-		_ = s.dbus.Emit("/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2.Player.Seeked", position)
+// EmitSeeked 发送 Seeked 信号，仅在用户主动 seek 时调用
+// https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Signal:Seeked
+func (s *RemoteControl) EmitSeeked(position time.Duration) {
+	if s.dbus == nil {
+		return
 	}
+	_ = s.dbus.Emit("/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2.Player.Seeked", UsFromDuration(position))
 }
 
 func (s *RemoteControl) setProp(iface, name string, value dbus.Variant) {

--- a/internal/remote_control/remote_control_windows.go
+++ b/internal/remote_control/remote_control_windows.go
@@ -111,6 +111,9 @@ func (c *RemoteControl) SetPosition(pos time.Duration) {
 	c.setTimelineProps(c.lastPlayingInfo)
 }
 
+func (c *RemoteControl) EmitSeeked(time.Duration) {
+}
+
 func (c *RemoteControl) SetPlayingInfo(info PlayingInfo) {
 	if c.smtc == nil {
 		return

--- a/internal/ui/player.go
+++ b/internal/ui/player.go
@@ -388,6 +388,7 @@ func (p *Player) PreviousSong(manual bool) {
 func (p *Player) Seek(duration time.Duration) {
 	p.Player.Seek(duration)
 	p.stateHandler.SetPlayingInfo(p.PlayingInfo())
+	p.stateHandler.EmitSeeked(duration)
 }
 
 // SetMode 设置播放模式


### PR DESCRIPTION
MPRIS 的 `Seeked` 信号在正常播放时被每帧（默认 200ms 一次）持续发送到 D-Bus。接收端比如 KDE Connect 监听到后会持续转发给手机，导致手机不断被唤醒处理，造成发热严重。

根据 [MPRIS 规范](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Signal:Seeked)，`Seeked` 信号只应在用户主动 seek 导致位置不连续变化时发射，不能在正常播放时持续发送。

### Issue for this PR / 本 PR 关联的 Issue

Closes #

---

### Type of change / 变更类型

- [x] Bug fix / Bug 修复
- [ ] New feature / 新功能
- [ ] Refactor | code improvement / 重构 | 代码优化
- [ ] Documentation / 文档更新

---

### What does this PR do? / 本 PR 做了什么？

- `remote_control_linux.go`: 将 `Seeked` 发射从 `SetPosition()` 中移除，新增 `EmitSeeked()` 方法，仅在真正 seek 时调用
- `player.go`: 在 `Seek()` 方法中调用 `EmitSeeked()`，确保用户 seek后仍能正确通知 MPRIS 客户端
- 其他平台（darwin/windows）添加空实现 stub

---

### How did you verify your code works? / 如何验证你的代码有效？

应用前播放音乐时，KDE Connect会占用10%左右的CPU；应用后为0%

<img width="446" height="95" alt="图片" src="https://github.com/user-attachments/assets/cc486822-61bd-4479-b7c4-7a5e3c6ae34a" />

<img width="446" height="95" alt="图片" src="https://github.com/user-attachments/assets/b70bc503-4aa0-4b53-b376-edc18495d743" />

---

### Checklist / 检查清单

- [x] I have tested my changes locally / 我已在本地测试了我的更改
- [x] I have not included unrelated changes in this PR / 本 PR 未包含无关的更改

---

_If you do not follow this template your PR will be automatically rejected._
_如果不按照此模板填写，你的 PR 可能会被自动关闭。_
