### PR TITLE
feat(mpris): 实现 MPRIS Seek / SetPosition D-Bus 方法

### DIFF
--- a/internal/remote_control/mpris_player_linux.go
+++ b/internal/remote_control/mpris_player_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"reflect"
 	"time"
 
 	"github.com/go-musicfox/go-musicfox/internal/types"
@@ -114,7 +115,7 @@ func (p *Player) createStatus(info PlayingInfo) {
 		"CanGoPrevious": newProp(true, nil),
 		"CanPlay":       newProp(true, nil),
 		"CanPause":      newProp(true, nil),
-		"CanSeek":       newProp(false, nil),
+		"CanSeek":       newProp(true, nil),
 		"CanControl":    newProp(true, nil),
 	}
 }
@@ -168,6 +169,46 @@ func (p *Player) Stop() *dbus.Error {
 func (p *Player) PlayPause() *dbus.Error {
 	log.Printf("Play/Pause requested. Switching context...\n")
 	p.RemoteControl.player.CtrlToggle()
+	return nil
+}
+
+// Seek seeks by an offset relative to the current position.
+// https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:Seek
+func (p *Player) Seek(offset int64) *dbus.Error {
+	log.Printf("Seek requested: offset=%d\n", offset)
+
+	// Get current position from properties
+	posVariant, dbusErr := p.RemoteControl.props.Get("org.mpris.MediaPlayer2.Player", "Position")
+	if dbusErr != nil {
+		return dbusErr
+	}
+
+	currentUs := reflect.ValueOf(posVariant.Value()).Int()
+
+	newUs := currentUs + offset
+	if newUs < 0 {
+		newUs = 0
+	}
+
+	p.RemoteControl.player.CtrlSeek(time.Duration(newUs) * time.Microsecond)
+	return nil
+}
+
+// SetPosition sets the absolute position of the current track.
+// https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Method:SetPosition
+func (p *Player) SetPosition(trackId dbus.ObjectPath, position int64) *dbus.Error {
+	log.Printf("SetPosition requested: trackId=%s, position=%d\n", trackId, position)
+
+	// MPRIS spec: if TrackId doesn't match the current track, ignore the request
+	if trackId != p.RemoteControl.currentTrack {
+		return nil
+	}
+
+	if position < 0 {
+		position = 0
+	}
+
+	p.RemoteControl.player.CtrlSeek(time.Duration(position) * time.Microsecond)
 	return nil
 }
 


### PR DESCRIPTION
实现 MPRIS Seek / SetPosition D-Bus 方法，使其可在可用的客户端（如 KDE Connect）中可拖拽进度条/快进快退

### Issue for this PR / 本 PR 关联的 Issue

Closes #

---

### Type of change / 变更类型

- [ ] Bug fix / Bug 修复
- [x] New feature / 新功能
- [ ] Refactor | code improvement / 重构 | 代码优化
- [ ] Documentation / 文档更新

---

### What does this PR do? / 本 PR 做了什么？

- `CanSeek` → `true`: 告知 MPRIS 客户端支持 seek 操作
- `Seek(offset int64)`: 实现相对位置 seek，接收偏移量（微秒），计算当前位置 + 偏移后执行 seek
- `SetPosition(trackId ObjectPath, position int64)`: 实现绝对位置 seek，根据 MPRIS 规范校验 TrackId，不匹配时忽略请求

---

### How did you verify your code works? / 如何验证你的代码有效？

<img width="455" height="378" alt="图片" src="https://github.com/user-attachments/assets/141c6a1a-18c4-43a8-bf7b-776437e79629" />

DankMaterialShell 和 KDE Connect 的进度条拖拽/快进可用


---

### Checklist / 检查清单

- [x] I have tested my changes locally / 我已在本地测试了我的更改
- [x] I have not included unrelated changes in this PR / 本 PR 未包含无关的更改

---

_If you do not follow this template your PR will be automatically rejected._
_如果不按照此模板填写，你的 PR 可能会被自动关闭。_
