### PR TITLE
fix(track): 修复 FLAC 下载缺少专辑封面

### DIFF
--- a/internal/track/tagger.go
+++ b/internal/track/tagger.go
@@ -131,7 +131,11 @@ func (m *metadataTagger) fetchCover(picURL string) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	return data, resp.Header.Get("Content-Type"), nil
+	mimeType := resp.Header.Get("Content-Type")
+	if mimeType == "image/jpg" {
+		mimeType = "image/jpeg"
+	}
+	return data, mimeType, nil
 }
 
 func (m *metadataTagger) setFlacCover(flacMeta *songtag.FLAC, song structs.Song) {

--- a/internal/track/tagger.go
+++ b/internal/track/tagger.go
@@ -131,11 +131,7 @@ func (m *metadataTagger) fetchCover(picURL string) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	mimeType := resp.Header.Get("Content-Type")
-	if mimeType == "image/jpg" {
-		mimeType = "image/jpeg"
-	}
-	return data, mimeType, nil
+	return data, http.DetectContentType(data), nil
 }
 
 func (m *metadataTagger) setFlacCover(flacMeta *songtag.FLAC, song structs.Song) {

--- a/internal/track/tagger_test.go
+++ b/internal/track/tagger_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"image"
 	"image/jpeg"
+	"image/png"
 	"io"
 	"net/http"
 	"testing"
@@ -18,36 +19,62 @@ func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) 
 	return f(request)
 }
 
-func TestSetFlacCoverAcceptsImageJPGAlias(t *testing.T) {
-	var cover bytes.Buffer
-	if err := jpeg.Encode(&cover, image.NewRGBA(image.Rect(0, 0, 1, 1)), nil); err != nil {
-		t.Fatalf("encode test cover: %v", err)
-	}
-
-	flacMetadata := &songtag.FLAC{}
-	tagger := metadataTagger{httpClient: &http.Client{
-		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
-			return &http.Response{
-				Status:     "200 OK",
-				StatusCode: http.StatusOK,
-				Header: http.Header{
-					"Content-Type": []string{"image/jpg"},
-				},
-				Body: io.NopCloser(bytes.NewReader(cover.Bytes())),
-			}, nil
-		}),
-	}}
-	tagger.setFlacCover(flacMetadata, structs.Song{
-		Id: 1,
-		Album: structs.Album{
-			PicUrl: "https://example.com/cover.jpg",
+func TestSetFlacCoverDetectsImageTypeFromData(t *testing.T) {
+	testCases := []struct {
+		name     string
+		mimeType string
+		encode   func(*bytes.Buffer) error
+	}{
+		{
+			name:     "JPEG",
+			mimeType: "image/jpeg",
+			encode: func(cover *bytes.Buffer) error {
+				return jpeg.Encode(cover, image.NewRGBA(image.Rect(0, 0, 1, 1)), nil)
+			},
 		},
-	})
-
-	for _, block := range flacMetadata.Blocks {
-		if block.Type == songtag.FlacPicture {
-			return
-		}
+		{
+			name:     "PNG with JPEG response header",
+			mimeType: "image/png",
+			encode: func(cover *bytes.Buffer) error {
+				return png.Encode(cover, image.NewRGBA(image.Rect(0, 0, 1, 1)))
+			},
+		},
 	}
-	t.Fatal("expected a FLAC picture metadata block")
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var cover bytes.Buffer
+			if err := testCase.encode(&cover); err != nil {
+				t.Fatalf("encode test cover: %v", err)
+			}
+
+			flacMetadata := &songtag.FLAC{}
+			tagger := metadataTagger{httpClient: &http.Client{
+				Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+					return &http.Response{
+						Status:     "200 OK",
+						StatusCode: http.StatusOK,
+						Header: http.Header{
+							"Content-Type": []string{"image/jpg"},
+						},
+						Body: io.NopCloser(bytes.NewReader(cover.Bytes())),
+					}, nil
+				}),
+			}}
+			tagger.setFlacCover(flacMetadata, structs.Song{
+				Id: 1,
+				Album: structs.Album{
+					PicUrl: "https://example.com/cover.jpg",
+				},
+			})
+
+			picture, err := flacMetadata.GetMetadataBlockPicture()
+			if err != nil {
+				t.Fatalf("read FLAC picture metadata block: %v", err)
+			}
+			if picture.MIME != testCase.mimeType {
+				t.Fatalf("expected %s MIME, got %q", testCase.mimeType, picture.MIME)
+			}
+		})
+	}
 }

--- a/internal/track/tagger_test.go
+++ b/internal/track/tagger_test.go
@@ -1,0 +1,53 @@
+package track
+
+import (
+	"bytes"
+	"image"
+	"image/jpeg"
+	"io"
+	"net/http"
+	"testing"
+
+	songtag "github.com/frolovo22/tag"
+	"github.com/go-musicfox/go-musicfox/internal/structs"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestSetFlacCoverAcceptsImageJPGAlias(t *testing.T) {
+	var cover bytes.Buffer
+	if err := jpeg.Encode(&cover, image.NewRGBA(image.Rect(0, 0, 1, 1)), nil); err != nil {
+		t.Fatalf("encode test cover: %v", err)
+	}
+
+	flacMetadata := &songtag.FLAC{}
+	tagger := metadataTagger{httpClient: &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type": []string{"image/jpg"},
+				},
+				Body: io.NopCloser(bytes.NewReader(cover.Bytes())),
+			}, nil
+		}),
+	}}
+	tagger.setFlacCover(flacMetadata, structs.Song{
+		Id: 1,
+		Album: structs.Album{
+			PicUrl: "https://example.com/cover.jpg",
+		},
+	})
+
+	for _, block := range flacMetadata.Blocks {
+		if block.Type == songtag.FlacPicture {
+			return
+		}
+	}
+	t.Fatal("expected a FLAC picture metadata block")
+}


### PR DESCRIPTION
### Issue for this PR

Closes #605

---

### Type of change

- [x] Bug fix / Bug 修复
- [ ] New feature / 新功能
- [ ] Refactor | code improvement / 重构 | 代码优化
- [ ] Documentation / 文档更新

---

### What does this PR do?

Musicfox 下载 FLAC 时直接信任网易云图片 CDN 的 `Content-Type`，但该响应头并不可靠：

- 部分 JPEG 封面返回非标准的 `image/jpg`；
- 部分 `.jpg` URL 且响应头为 `image/jpg` 的封面，实际字节内容却是 PNG（例如歌曲 ID `22813546`）。

前一种情况会触发 `Unsupported MIME`，后一种情况即使把 `image/jpg` 规范化为 `image/jpeg`，仍会因为 PNG 数据不是 JPEG 而失败。两种情况都会导致歌曲下载成功，但 FLAC 没有写入 `PICTURE` metadata block。

本 PR 使用 `http.DetectContentType(data)` 按已下载的图片字节识别真实 MIME，再交给 `flacpicture` 写入封面。没有引入依赖，也不改变音频下载或其他标签流程。回归测试同时覆盖标准 JPEG 与“响应头声称 JPG、内容实际为 PNG”两种情况。

---

### How did you verify your code works?

- `go test -mod=vendor ./internal/track -run '^TestSetFlacCoverDetectsImageTypeFromData$' -count=1`：通过
- `go test -mod=vendor ./internal/track -count=1`：通过
- `make build`：通过
- 使用歌曲 ID `22813546` 的真实 CDN 响应验证：响应头为 `image/jpg`、内容为 638×638 PNG；修复后生成的 FLAC picture MIME 为 `image/png`，嵌入图片字节与下载内容一致
- `gofmt` 与 `git diff --check`：通过
- 全量测试已执行；当前 `master` 的 `internal/playlist/TestPlaylistManagerWithUIInteraction` 会在“列表随机”场景报 `no next song`，与本 PR 修改的 `internal/track` 无关
- `go vet ./internal/... ./utils/...` 已执行；当前 `master` 的 MPRIS `Seek` 方法签名检查失败，与本 PR 无关

---

### Screenshots / recordings

不适用（非 UI 变更）。

---

### Checklist

- [x] I have tested my changes locally / 我已在本地测试了我的更改
- [x] I have not included unrelated changes in this PR / 本 PR 未包含无关的更改