### PR TITLE
feat(lyric): fetch unmatched cloud lyrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ type Player interface {
 
 ### 其他模块
 
-- **歌词**：LRC/YRC 格式，支持 smooth/wave/glow 渲染模式
+- **歌词**：LRC/YRC 格式，支持 smooth/wave/glow 渲染模式；未匹配的云盘歌曲（含旧播放快照）优先通过云盘歌词接口获取内嵌歌词，失败时回退普通歌曲歌词接口
 - **播放列表**：列表循环/顺序/单曲循环/随机/无限随机/智能心动模式
 - **远程控制**：MPRIS(linux)、Now Playing(macOS)、System Media(Windows)
 - **存储**：BoltDB，存储用户信息、播放状态、播放列表快照和桌面歌词窗口位置/显示器

--- a/internal/lyric/fetcher.go
+++ b/internal/lyric/fetcher.go
@@ -8,5 +8,5 @@ import (
 
 // Fetcher defines the behavior for retrieving structured lyric data for a song.
 type Fetcher interface {
-	GetLyric(ctx context.Context, songID int64) (structs.LRCData, error)
+	GetLyric(ctx context.Context, song structs.Song) (structs.LRCData, error)
 }

--- a/internal/lyric/service.go
+++ b/internal/lyric/service.go
@@ -102,7 +102,7 @@ func (s *Service) SetSong(ctx context.Context, song structs.Song) error {
 
 	s.resetState(true) // Preserve configuration on reset
 
-	lrcData, err := s.fetcher.GetLyric(ctx, song.Id)
+	lrcData, err := s.fetcher.GetLyric(ctx, song)
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch lyric data")
 	}

--- a/internal/track/fetcher.go
+++ b/internal/track/fetcher.go
@@ -17,6 +17,7 @@ type Fetcher interface {
 	FetchPlayableInfo(ctx context.Context, songID int64) (*netease.PlayableInfo, error)
 	FetchStream(ctx context.Context, source PlayableSource) (io.ReadCloser, error)
 	FetchLyric(ctx context.Context, songID int64) (structs.LRCData, error)
+	FetchCloudLyric(ctx context.Context, userID, songID int64) (structs.LRCData, error)
 }
 
 type fetcher struct {
@@ -80,6 +81,14 @@ func (f *fetcher) FetchLyric(ctx context.Context, songID int64) (structs.LRCData
 	lrcData, err := netease.FetchLyric(songID)
 	if err != nil {
 		return structs.LRCData{}, errors.Wrapf(err, "failed to fetch lyric for song %d", songID)
+	}
+	return lrcData, nil
+}
+
+func (f *fetcher) FetchCloudLyric(ctx context.Context, userID, songID int64) (structs.LRCData, error) {
+	lrcData, err := netease.FetchCloudLyric(userID, songID)
+	if err != nil {
+		return structs.LRCData{}, errors.Wrapf(err, "failed to fetch cloud lyric for song %d", songID)
 	}
 	return lrcData, nil
 }

--- a/internal/track/manager.go
+++ b/internal/track/manager.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 
 	"github.com/go-musicfox/netease-music/service"
 	"golang.org/x/sync/errgroup"
@@ -40,6 +41,7 @@ type Manager struct {
 	lyricDir    string
 	quality     service.SongQualityLevel
 	sfGroup     singleflight.Group
+	cloudUserID atomic.Int64
 }
 
 // ManagerOption 是用于配置 Manager 的函数类型。
@@ -195,7 +197,7 @@ func (m *Manager) DownloadLyric(ctx context.Context, song structs.Song) (string,
 			return filePath, os.ErrExist
 		}
 
-		lrc, err := m.GetLyric(ctx, song.Id)
+		lrc, err := m.GetLyric(ctx, song)
 		if err != nil {
 			return "", err
 		}
@@ -216,16 +218,52 @@ func (m *Manager) DownloadLyric(ctx context.Context, song structs.Song) (string,
 }
 
 // GetLyric 获取一首歌的歌词。
-func (m *Manager) GetLyric(ctx context.Context, songID int64) (structs.LRCData, error) {
-	key := fmt.Sprintf("lyric-fetch-%d", songID)
+func (m *Manager) GetLyric(ctx context.Context, song structs.Song) (structs.LRCData, error) {
+	cloudUserID := m.cloudUserID.Load()
+	preferCloudLyric := shouldPreferCloudLyric(song)
+	key := fmt.Sprintf("lyric-fetch-%d-%d-%t", cloudUserID, song.Id, preferCloudLyric)
 	result, err, _ := m.sfGroup.Do(key, func() (any, error) {
-		return m.fetcher.FetchLyric(ctx, songID)
+		if preferCloudLyric && cloudUserID != 0 {
+			data, cloudErr := m.fetcher.FetchCloudLyric(ctx, cloudUserID, song.Id)
+			if cloudErr == nil && data.Original != "" {
+				return data, nil
+			}
+			if cloudErr != nil {
+				slog.Debug("Failed to fetch embedded cloud lyric, falling back to regular lyric",
+					"songId", song.Id, "error", cloudErr)
+			} else {
+				slog.Debug("Cloud lyric response empty, falling back to regular lyric",
+					"songId", song.Id)
+			}
+		}
+		return m.fetcher.FetchLyric(ctx, song.Id)
 	})
 
 	if err != nil {
 		return structs.LRCData{}, err
 	}
 	return result.(structs.LRCData), nil
+}
+
+func shouldPreferCloudLyric(song structs.Song) bool {
+	if song.UnMatched {
+		return true
+	}
+	if song.DjRadioEpisodeId != 0 || song.Album.Id != 0 || len(song.Artists) == 0 {
+		return false
+	}
+	for _, artist := range song.Artists {
+		if artist.Id != 0 {
+			return false
+		}
+	}
+	// Older playlist snapshots may lack UnMatched but retain zero-ID cloud metadata.
+	return true
+}
+
+// SetCloudUserID updates the account used to fetch cloud disk lyrics.
+func (m *Manager) SetCloudUserID(userID int64) {
+	m.cloudUserID.Store(userID)
 }
 
 func (m *Manager) ClearCache() error {

--- a/internal/track/manager_lyric_test.go
+++ b/internal/track/manager_lyric_test.go
@@ -1,0 +1,156 @@
+package track
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/go-musicfox/go-musicfox/internal/structs"
+	"github.com/go-musicfox/go-musicfox/utils/netease"
+)
+
+type lyricFetcherStub struct {
+	regular      structs.LRCData
+	cloud        structs.LRCData
+	cloudErr     error
+	userID       int64
+	songID       int64
+	regularCalls int
+	cloudCalls   int
+}
+
+func (f lyricFetcherStub) FetchPlayableInfo(context.Context, int64) (*netease.PlayableInfo, error) {
+	return nil, nil
+}
+
+func (f lyricFetcherStub) FetchStream(context.Context, PlayableSource) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
+func (f *lyricFetcherStub) FetchLyric(context.Context, int64) (structs.LRCData, error) {
+	f.regularCalls++
+	return f.regular, nil
+}
+
+func (f *lyricFetcherStub) FetchCloudLyric(_ context.Context, userID, songID int64) (structs.LRCData, error) {
+	f.cloudCalls++
+	f.userID = userID
+	f.songID = songID
+	return f.cloud, f.cloudErr
+}
+
+func TestGetLyricUsesEmbeddedLyricsForUnmatchedCloudSong(t *testing.T) {
+	fetcher := &lyricFetcherStub{
+		regular: structs.LRCData{Original: "[00:00.00]regular"},
+		cloud:   structs.LRCData{Original: "[00:00.00]embedded"},
+	}
+	manager := &Manager{fetcher: fetcher}
+	manager.SetCloudUserID(54321)
+	manager.SetCloudUserID(12345)
+
+	got, err := manager.GetLyric(context.Background(), structs.Song{
+		Id:        42,
+		UnMatched: true,
+	})
+	if err != nil {
+		t.Fatalf("get lyric: %v", err)
+	}
+	if got.Original != "[00:00.00]embedded" {
+		t.Fatalf("original lyric = %q, want embedded cloud lyric", got.Original)
+	}
+	if fetcher.userID != 12345 || fetcher.songID != 42 {
+		t.Fatalf("cloud lyric IDs = (%d, %d), want (12345, 42)", fetcher.userID, fetcher.songID)
+	}
+	if fetcher.cloudCalls != 1 || fetcher.regularCalls != 0 {
+		t.Fatalf("fetch calls = (cloud %d, regular %d), want (1, 0)", fetcher.cloudCalls, fetcher.regularCalls)
+	}
+}
+
+func TestGetLyricUsesRegularLyricsWithoutCloudUser(t *testing.T) {
+	manager := &Manager{fetcher: &lyricFetcherStub{
+		regular: structs.LRCData{Original: "[00:00.00]regular"},
+		cloud:   structs.LRCData{Original: "[00:00.00]embedded"},
+	}}
+
+	got, err := manager.GetLyric(context.Background(), structs.Song{
+		Id:        42,
+		UnMatched: true,
+	})
+	if err != nil {
+		t.Fatalf("get lyric: %v", err)
+	}
+	if got.Original != "[00:00.00]regular" {
+		t.Fatalf("original lyric = %q, want regular lyric without current cloud user", got.Original)
+	}
+}
+
+func TestGetLyricFallsBackWhenEmbeddedCloudLyricsAreUnavailable(t *testing.T) {
+	fetcher := &lyricFetcherStub{
+		regular:  structs.LRCData{Original: "[00:00.00]regular"},
+		cloudErr: errors.New("no embedded lyric"),
+	}
+	manager := &Manager{fetcher: fetcher}
+	manager.SetCloudUserID(12345)
+
+	got, err := manager.GetLyric(context.Background(), structs.Song{
+		Id:        42,
+		UnMatched: true,
+	})
+	if err != nil {
+		t.Fatalf("get lyric: %v", err)
+	}
+	if got.Original != "[00:00.00]regular" {
+		t.Fatalf("original lyric = %q, want regular lyric fallback", got.Original)
+	}
+	if fetcher.cloudCalls != 1 || fetcher.regularCalls != 1 {
+		t.Fatalf("fetch calls = (cloud %d, regular %d), want (1, 1)", fetcher.cloudCalls, fetcher.regularCalls)
+	}
+}
+
+func TestGetLyricUsesCloudLyricsForLegacyUnmatchedSnapshot(t *testing.T) {
+	fetcher := &lyricFetcherStub{
+		regular: structs.LRCData{Original: "[00:00.00]regular"},
+		cloud:   structs.LRCData{Original: "[00:00.00]embedded"},
+	}
+	manager := &Manager{fetcher: fetcher}
+	manager.SetCloudUserID(12345)
+
+	got, err := manager.GetLyric(context.Background(), structs.Song{
+		Id:      42,
+		Album:   structs.Album{Id: 0},
+		Artists: []structs.Artist{{Id: 0, Name: "artist"}},
+	})
+	if err != nil {
+		t.Fatalf("get lyric: %v", err)
+	}
+	if got.Original != "[00:00.00]embedded" {
+		t.Fatalf("original lyric = %q, want embedded cloud lyric", got.Original)
+	}
+	if fetcher.cloudCalls != 1 || fetcher.regularCalls != 0 {
+		t.Fatalf("fetch calls = (cloud %d, regular %d), want (1, 0)", fetcher.cloudCalls, fetcher.regularCalls)
+	}
+}
+
+func TestGetLyricKeepsRegularLyricsForMatchedCloudSong(t *testing.T) {
+	fetcher := &lyricFetcherStub{
+		regular: structs.LRCData{Original: "[00:00.00]regular"},
+		cloud:   structs.LRCData{Original: "[00:00.00]embedded"},
+	}
+	manager := &Manager{fetcher: fetcher}
+	manager.SetCloudUserID(12345)
+
+	got, err := manager.GetLyric(context.Background(), structs.Song{
+		Id: 186001,
+	})
+	if err != nil {
+		t.Fatalf("get lyric: %v", err)
+	}
+	if got.Original != "[00:00.00]regular" {
+		t.Fatalf("original lyric = %q, want regular lyric", got.Original)
+	}
+	if fetcher.cloudCalls != 0 || fetcher.regularCalls != 1 {
+		t.Fatalf("fetch calls = (cloud %d, regular %d), want (0, 1)", fetcher.cloudCalls, fetcher.regularCalls)
+	}
+}

--- a/internal/ui/netease.go
+++ b/internal/ui/netease.go
@@ -262,6 +262,12 @@ func (n *Netease) InitHook(_ *model.App) {
 			}
 		}
 
+		cloudUserID := int64(0)
+		if n.user != nil {
+			cloudUserID = n.user.UserId
+		}
+		n.trackManager.SetCloudUserID(cloudUserID)
+
 		// 刷新界面用户名
 		n.MustMain().RefreshMenuTitle()
 
@@ -564,6 +570,7 @@ func (n *Netease) LoginCallback() error {
 		return errors.WithMessagef(err, "parse user err, code: %f, resp: %s", code, string(resp))
 	}
 	n.user = &user
+	n.trackManager.SetCloudUserID(user.UserId)
 
 	// 获取我喜欢的歌单
 	userPlaylists := service.UserPlaylistService{

--- a/utils/netease/lyric.go
+++ b/utils/netease/lyric.go
@@ -87,3 +87,41 @@ func FetchLyric(songID int64) (structs.LRCData, error) {
 
 	return data, nil
 }
+
+// FetchCloudLyric fetches the embedded LYRICS tag for a cloud disk song.
+func FetchCloudLyric(userID, songID int64) (structs.LRCData, error) {
+	options := &util.Options{
+		Crypto:  "eapi",
+		Url:     "/api/cloud/lyric/get",
+		Cookies: []*http.Cookie{{Name: "os", Value: "pc"}},
+	}
+	params := map[string]string{
+		"userId": strconv.FormatInt(userID, 10),
+		"songId": strconv.FormatInt(songID, 10),
+		"lv":     "-1",
+		"kv":     "-1",
+	}
+	code, response, _ := util.CreateRequest(
+		"POST",
+		"https://music.163.com/eapi/cloud/lyric/get",
+		params,
+		options,
+	)
+
+	return parseCloudLyricResponse(code, response)
+}
+
+func parseCloudLyricResponse(code float64, response []byte) (structs.LRCData, error) {
+	var data structs.LRCData
+	if code != 200 {
+		return data, fmt.Errorf("netease cloud lyric api returned status code: %v", code)
+	}
+
+	lyric, err := jsonparser.GetString(response, "lrc")
+	if err != nil || lyric == "" {
+		return data, fmt.Errorf("netease cloud lyric api returned no lyric")
+	}
+	data.Original = lyric
+	data.Translated = "[00:00.00]"
+	return data, nil
+}

--- a/utils/netease/lyric_test.go
+++ b/utils/netease/lyric_test.go
@@ -1,0 +1,33 @@
+package netease
+
+import "testing"
+
+func TestParseCloudLyricResponse(t *testing.T) {
+	const want = "[00:00.00]作词 : 刘畊宏\n[00:01.00]作曲 : 周杰伦"
+
+	got, err := parseCloudLyricResponse(200, []byte(`{"code":200,"lrc":"[00:00.00]作词 : 刘畊宏\n[00:01.00]作曲 : 周杰伦"}`))
+	if err != nil {
+		t.Fatalf("parse cloud lyric response: %v", err)
+	}
+	if got.Original != want {
+		t.Fatalf("original lyric = %q, want %q", got.Original, want)
+	}
+}
+
+func TestParseCloudLyricResponseRejectsMissingLyrics(t *testing.T) {
+	if _, err := parseCloudLyricResponse(200, []byte(`{"code":200}`)); err == nil {
+		t.Fatal("expected missing cloud lyric to return an error")
+	}
+}
+
+func TestParseCloudLyricResponseRejectsEmptyLyrics(t *testing.T) {
+	if _, err := parseCloudLyricResponse(200, []byte(`{"code":200,"lrc":""}`)); err == nil {
+		t.Fatal("expected empty cloud lyric to return an error")
+	}
+}
+
+func TestParseCloudLyricResponseRejectsFailedRequest(t *testing.T) {
+	if _, err := parseCloudLyricResponse(401, []byte(`{"code":401}`)); err == nil {
+		t.Fatal("expected failed cloud lyric request to return an error")
+	}
+}


### PR DESCRIPTION
### Issue for this PR

N/A

---

### Type of change

- [ ] Bug fix / Bug 修复
- [x] New feature / 新功能
- [ ] Refactor | code improvement / 重构 | 代码优化
- [ ] Documentation / 文档更新

---

### What does this PR do?

我在网易云客户端播放云盘歌曲时可以正常看到歌词，但在 musicfox 中播放同一首歌却显示“暂无歌词”，因此尝试补充云盘歌曲的歌词获取支持。

本 PR 对这类歌曲优先请求云盘歌词接口，并在请求失败或没有内嵌歌词时回退到原有接口。同时兼容缺少 `UnMatched` 标记的旧播放列表快照。

---

### How did you verify your code works?

- `go test ./...`
- `go test -race ./internal/track ./utils/netease`
- 编译并运行本地 `purego` 版本
- 使用实际云盘歌曲验证普通接口无歌词、云盘接口有歌词的场景，并验证旧快照形态能够取得云盘歌词

---

### Screenshots / recordings

N/A（无 UI 变更）

---

### Checklist

- [x] I have tested my changes locally / 我已在本地测试了我的更改
- [x] I have not included unrelated changes in this PR / 本 PR 未包含无关的更改
