### PR TITLE
fix(beep_player):修复 beep 播放的进度与时间播放在播放期间，时间持续落后于真实播放进度

### DIFF
--- a/internal/player/beep_player.go
+++ b/internal/player/beep_player.go
@@ -226,7 +226,7 @@ func (p *beepPlayer) listen() {
 				OnDone:         func(stopped bool) {},
 				OnTick: func() {
 					select {
-					case p.timeChan <- p.timer.Passed():
+					case p.timeChan <- time.Duration(p.curStreamer.Position()) * time.Second / time.Duration(p.curFormat.SampleRate):
 					default:
 					}
 				},
@@ -273,10 +273,10 @@ func (p *beepPlayer) StateChan() <-chan types.State {
 }
 
 func (p *beepPlayer) PassedTime() time.Duration {
-	if p.timer == nil {
+	if p.curStreamer == nil {
 		return 0
 	}
-	return p.timer.Passed()
+	return time.Duration(p.curStreamer.Position()) * time.Second / time.Duration(p.curFormat.SampleRate)
 }
 
 func (p *beepPlayer) PlayedTime() time.Duration {


### PR DESCRIPTION
### Issue for this PR / 本 PR 关联的 Issue

Closes #610

---

### Type of change / 变更类型

- [x] Bug fix / Bug 修复
- [ ] New feature / 新功能
- [ ] Refactor | code improvement / 重构 | 代码优化
- [ ] Documentation / 文档更新

---

### What does this PR do? / 本 PR 做了什么？

beep的返回的时间慢于真实播放时间
beep的时间 原先是由  timer计时器 提供 
现在由beep的Position() 提供 
https://pkg.go.dev/github.com/gopxl/beep#StreamSeekCloser
---


### How did you verify your code works? / 如何验证你的代码有效？

测试为go run cmd/musicfox.go --debug --verbose 4                                                                                                                                                                                                                          实际播放 放在下面了

****
---

### Screenshots / recordings / 截图 / 录屏

<img width="1920" height="1080" alt="截图" src="https://github.com/user-attachments/assets/6769e165-87e6-4e60-b9f2-3b86952648b6" />

---

### Checklist / 检查清单

- [x] I have tested my changes locally / 我已在本地测试了我的更改
- [x] I have not included unrelated changes in this PR / 本 PR 未包含无关的更改

---

_If you do not follow this template your PR will be automatically rejected._
_如果不按照此模板填写，你的 PR 可能会被自动关闭。_
