### PR TITLE
perf: bound UI render rate and eliminate per-frame rendering costs; fix player/spectrum races

### DIFF
--- a/internal/player/beep_player.go
+++ b/internal/player/beep_player.go
@@ -117,8 +117,11 @@ func (p *beepPlayer) listen() {
 			return
 		case <-done:
 			p.Stop()
-		case p.curMusic = <-p.musicChan:
+		case music := <-p.musicChan:
 			p.l.Lock()
+			// curMusic is read by CurMusic() (UI thread) under p.l, so assign
+			// it while holding the lock too.
+			p.curMusic = music
 			p.pausedNoLock()
 			if p.timer != nil {
 				p.timer.SetPassed(0)
@@ -225,6 +228,15 @@ func (p *beepPlayer) listen() {
 				OnPause:        func() {},
 				OnDone:         func(stopped bool) {},
 				OnTick: func() {
+					// Guard with p.l: curStreamer/curFormat are replaced (and
+					// curStreamer set to nil) under p.l by reset() during song
+					// switches. Reading them lock-free from the timer goroutine
+					// races with that and can panic on a nil interface.
+					p.l.Lock()
+					defer p.l.Unlock()
+					if p.curStreamer == nil || p.curFormat.SampleRate == 0 {
+						return
+					}
 					select {
 					case p.timeChan <- time.Duration(p.curStreamer.Position()) * time.Second / time.Duration(p.curFormat.SampleRate):
 					default:
@@ -251,6 +263,8 @@ func (p *beepPlayer) Play(music URLMusic) {
 }
 
 func (p *beepPlayer) CurMusic() URLMusic {
+	p.l.Lock()
+	defer p.l.Unlock()
 	return p.curMusic
 }
 

--- a/internal/player/beep_player.go
+++ b/internal/player/beep_player.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gopxl/beep"
@@ -44,7 +45,7 @@ type beepPlayer struct {
 	curStreamer beep.StreamSeekCloser
 	curFormat   beep.Format
 
-	state      types.State
+	state      atomic.Uint32 // types.State, atomically read/written (setState runs under p.l; State() is called from the UI thread)
 	ctrl       *beep.Ctrl
 	volume     *effects.Volume
 	timeChan   chan time.Duration
@@ -60,8 +61,6 @@ type beepPlayer struct {
 
 func NewBeepPlayer() *beepPlayer {
 	p := &beepPlayer{
-		state: types.Stopped,
-
 		timeChan:  make(chan time.Duration, 1),
 		stateChan: make(chan types.State, 10),
 		musicChan: make(chan URLMusic, 1),
@@ -79,6 +78,8 @@ func NewBeepPlayer() *beepPlayer {
 	if configs.AppConfig.Main.Visualizer.Enable || (configs.AppConfig.Main.Lyric.DesktopLyrics.SpectrumEnabled && desktopLyricsAvailable) {
 		p.spectrum = NewPCMAnalyzer(configs.AppConfig.Main.FrameRate.Interval())
 	}
+
+	p.state.Store(uint32(types.Stopped))
 
 	errorx.WaitGoStart(p.listen)
 
@@ -269,7 +270,7 @@ func (p *beepPlayer) CurMusic() URLMusic {
 }
 
 func (p *beepPlayer) setState(state types.State) {
-	p.state = state
+	p.state.Store(uint32(state))
 	select {
 	case p.stateChan <- state:
 	case <-time.After(time.Second * 2):
@@ -278,7 +279,7 @@ func (p *beepPlayer) setState(state types.State) {
 
 // State 当前状态
 func (p *beepPlayer) State() types.State {
-	return p.state
+	return types.State(p.state.Load())
 }
 
 // StateChan 状态发生变更
@@ -287,6 +288,8 @@ func (p *beepPlayer) StateChan() <-chan types.State {
 }
 
 func (p *beepPlayer) PassedTime() time.Duration {
+	p.l.Lock()
+	defer p.l.Unlock()
 	if p.curStreamer == nil {
 		return 0
 	}
@@ -294,6 +297,8 @@ func (p *beepPlayer) PassedTime() time.Duration {
 }
 
 func (p *beepPlayer) PlayedTime() time.Duration {
+	p.l.Lock()
+	defer p.l.Unlock()
 	if p.timer == nil {
 		return 0
 	}
@@ -316,7 +321,7 @@ func (p *beepPlayer) Seek(duration time.Duration) {
 	if p.curStreamer == nil || p.curMusic.Type != Mp3 || configs.AppConfig.Player.Beep.Mp3Decoder == types.BeepMiniMp3Decoder {
 		return
 	}
-	if p.state == types.Playing || p.state == types.Paused {
+	if types.State(p.state.Load()) == types.Playing || types.State(p.state.Load()) == types.Paused {
 		speaker.Lock()
 		newPos := p.curFormat.SampleRate.N(duration)
 
@@ -387,7 +392,7 @@ func (p *beepPlayer) SetVolume(volume int) {
 }
 
 func (p *beepPlayer) pausedNoLock() {
-	if p.state != types.Playing {
+	if types.State(p.state.Load()) != types.Playing {
 		return
 	}
 	p.ctrl.Paused = true
@@ -403,7 +408,7 @@ func (p *beepPlayer) Pause() {
 }
 
 func (p *beepPlayer) resumeNoLock() {
-	if p.state == types.Playing {
+	if types.State(p.state.Load()) == types.Playing {
 		return
 	}
 	p.ctrl.Paused = false
@@ -419,7 +424,7 @@ func (p *beepPlayer) Resume() {
 }
 
 func (p *beepPlayer) stopNoLock() {
-	if p.state == types.Stopped {
+	if types.State(p.state.Load()) == types.Stopped {
 		return
 	}
 	p.ctrl.Paused = true

--- a/internal/player/spectrum.go
+++ b/internal/player/spectrum.go
@@ -148,6 +148,9 @@ func (a *PCMAnalyzer) NewConsumer() func(sampleRate float64, samplesL, samplesR 
 	a.frameMu.Unlock()
 
 	// Clear raw ring buffer for new audio source.
+	// The ring elements are guarded by rawMu (written in consume, read in
+	// RawSamples), so the reset must hold the same lock.
+	a.rawMu.Lock()
 	a.rawRingPos.Store(0)
 	a.rawRingCount.Store(0)
 	a.rawSampleRate.Store(0)
@@ -155,6 +158,7 @@ func (a *PCMAnalyzer) NewConsumer() func(sampleRate float64, samplesL, samplesR 
 		a.rawRingL[i] = 0
 		a.rawRingR[i] = 0
 	}
+	a.rawMu.Unlock()
 	// Reset FFT averaging state.
 	a.avgLevelsL = [SpectrumBandCount]float64{}
 	a.avgLevelsR = [SpectrumBandCount]float64{}
@@ -170,6 +174,9 @@ func (a *PCMAnalyzer) consume(generation uint64, sampleRate float64, samplesL, s
 	}
 
 	// Copy to raw PCM ring buffer for oscilloscope/vectorscope.
+	// Ring elements are guarded by rawMu; RawSamples linearizes them under the
+	// same lock, so writes must take it too.
+	a.rawMu.Lock()
 	a.rawSampleRate.Store(math.Float64bits(sampleRate))
 	count := min(len(samplesL), rawSampleBufferSize)
 	pos := int(a.rawRingPos.Load())
@@ -185,6 +192,7 @@ func (a *PCMAnalyzer) consume(generation uint64, sampleRate float64, samplesL, s
 	if c := a.rawRingCount.Load(); c < rawSampleBufferSize {
 		a.rawRingCount.Store(min(c+uint32(count), rawSampleBufferSize))
 	}
+	a.rawMu.Unlock()
 
 	for i := range a.slots {
 		slot := &a.slots[i]

--- a/internal/player/spectrum.go
+++ b/internal/player/spectrum.go
@@ -144,7 +144,6 @@ func (a *PCMAnalyzer) NewConsumer() func(sampleRate float64, samplesL, samplesR 
 	generation := a.generation.Add(1)
 	a.frameMu.Lock()
 	a.frame = SpectrumFrame{}
-	a.target = SpectrumFrame{}
 	a.frameMu.Unlock()
 
 	// Clear raw ring buffer for new audio source.
@@ -159,9 +158,10 @@ func (a *PCMAnalyzer) NewConsumer() func(sampleRate float64, samplesL, samplesR 
 		a.rawRingR[i] = 0
 	}
 	a.rawMu.Unlock()
-	// Reset FFT averaging state.
-	a.avgLevelsL = [SpectrumBandCount]float64{}
-	a.avgLevelsR = [SpectrumBandCount]float64{}
+	// Note: avgLevelsL/R and target are intentionally NOT reset here — they are
+	// owned by the analyze goroutine, which detects the generation bump (in
+	// analyzeLatest) and resets them before the first frame of the new source.
+	// A concurrent write here would race with the running analyze loop.
 
 	return func(sampleRate float64, samplesL, samplesR []float32) {
 		a.consume(generation, sampleRate, samplesL, samplesR)

--- a/internal/player/spectrum_test.go
+++ b/internal/player/spectrum_test.go
@@ -204,3 +204,35 @@ func TestPCMAnalyzerRawRingResetConcurrent(t *testing.T) {
 	}
 	<-done
 }
+
+// TestPCMAnalyzerStateResetConcurrentNoRace runs the analyze loop at a short
+// interval (so avgLevels/target are actively read and written in the run
+// goroutine) while NewConsumer resets the analyzer state concurrently — the
+// song-switch pattern. Regression test for the avgLevelsL/R + target data
+// races, which the idle-loop tests below cannot trigger.
+func TestPCMAnalyzerStateResetConcurrentNoRace(t *testing.T) {
+	analyzer := NewPCMAnalyzer(time.Millisecond)
+	defer analyzer.Close()
+
+	samples := make([]float32, 256)
+	for i := range samples {
+		samples[i] = float32(i%17) / 17
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 300; i++ {
+			consumer := analyzer.NewConsumer()
+			for j := 0; j < 20; j++ {
+				consumer(44100, samples, nil)
+				time.Sleep(200 * time.Microsecond)
+			}
+		}
+	}()
+	for i := 0; i < 300; i++ {
+		_ = analyzer.Spectrum()
+		time.Sleep(200 * time.Microsecond)
+	}
+	<-done
+}

--- a/internal/player/spectrum_test.go
+++ b/internal/player/spectrum_test.go
@@ -153,3 +153,54 @@ func findPeakBand(levels [SpectrumBandCount]float64) int {
 	}
 	return peakBand
 }
+
+// TestPCMAnalyzerRawRingConcurrentReadWriteNoRace exercises the raw PCM ring
+// buffer from both sides at once: the audio callback (consume) writes while the
+// render side (RawSamples) reads. Regression test for the data race between the
+// two; run with -race.
+func TestPCMAnalyzerRawRingConcurrentReadWriteNoRace(t *testing.T) {
+	analyzer := NewPCMAnalyzer(time.Hour) // long interval: keep analyze loop idle
+	defer analyzer.Close()
+	consumer := analyzer.NewConsumer()
+
+	samples := make([]float32, 64)
+	for i := range samples {
+		samples[i] = float32(i) / 64
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 2000; i++ {
+			consumer(44100, samples, nil)
+		}
+	}()
+
+	for i := 0; i < 2000; i++ {
+		frame := analyzer.RawSamples()
+		if frame.Count > len(frame.SamplesL) {
+			t.Fatalf("RawSamples returned count %d > buffer %d", frame.Count, len(frame.SamplesL))
+		}
+	}
+	<-done
+}
+
+// TestPCMAnalyzerRawRingResetConcurrent ensures NewConsumer's ring reset does
+// not race with RawSamples reads either.
+func TestPCMAnalyzerRawRingResetConcurrent(t *testing.T) {
+	analyzer := NewPCMAnalyzer(time.Hour)
+	defer analyzer.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 200; i++ {
+			consumer := analyzer.NewConsumer()
+			consumer(44100, []float32{0.1, 0.2, 0.3}, nil)
+		}
+	}()
+	for i := 0; i < 200; i++ {
+		_ = analyzer.RawSamples()
+	}
+	<-done
+}

--- a/internal/ui/cover_renderer.go
+++ b/internal/ui/cover_renderer.go
@@ -29,7 +29,11 @@ type CoverRenderer struct {
 	imageCache   *kitty.ImageCache
 	kittySupport bool
 
-	mu            sync.Mutex
+	mu sync.Mutex
+	// writeMu serializes direct os.Stdout writes from the render thread, the
+	// animation goroutine and Close(), so kitty sequences never interleave
+	// and corrupt the escape stream.
+	writeMu       sync.Mutex
 	currentSongId int64  // Track currently displayed song to avoid redundant renders
 	cachedSeq     string // Cached kitty sequence
 	lastStartRow  int    // Last rendered start row position
@@ -227,6 +231,10 @@ func (r *CoverRenderer) View(a *model.App, main *model.Main) (view string, lines
 	} else {
 		kitty.CoverZIndex = 1
 	}
+	// Capture the z-index under the lock: the animation goroutine renders
+	// asynchronously and must not read the mutable global (it races with the
+	// next View() call that may flip it on a theme change).
+	zIndex := kitty.CoverZIndex
 	// Invalidate cached sequences when background transparency changes,
 	// since the kitty sequence embeds a z-index that is now stale.
 	// Always clear the image cache regardless of current render state:
@@ -245,8 +253,7 @@ func (r *CoverRenderer) View(a *model.App, main *model.Main) (view string, lines
 		if mx, my, mw, mh, ok := a.TopModalBounds(); ok {
 			if rectsOverlap(coverStartCol-1, coverStartRow-1, r.cols, r.rows, mx, my, mw, mh) {
 				if r.imageRendered {
-					_, _ = os.Stdout.WriteString(kitty.DeleteAllImages())
-					_ = os.Stdout.Sync()
+					r.writeStdout(kitty.DeleteAllImages())
 					r.imageRendered = false
 					r.cachedSeq = ""
 				}
@@ -273,8 +280,7 @@ func (r *CoverRenderer) View(a *model.App, main *model.Main) (view string, lines
 			// Verify this result is for the song we still want to show
 			if res.songID == song.Id {
 				// Apply to terminal
-				_, _ = os.Stdout.WriteString(res.sequence)
-				_ = os.Stdout.Sync()
+				r.writeStdout(res.sequence)
 
 				r.currentSongId = res.songID
 				r.animImageID = res.animID
@@ -303,12 +309,10 @@ func (r *CoverRenderer) View(a *model.App, main *model.Main) (view string, lines
 		if stateChanged && r.imageRendered && r.animImageID != 0 {
 			if playerState == types.Paused {
 				// Pause animation
-				_, _ = os.Stdout.WriteString(kitty.StopAnimation(r.animImageID))
-				_ = os.Stdout.Sync()
+				r.writeStdout(kitty.StopAnimation(r.animImageID))
 			} else if playerState == types.Playing && r.lastPlayerState == types.Paused {
 				// Resume animation
-				_, _ = os.Stdout.WriteString(kitty.StartAnimation(r.animImageID))
-				_ = os.Stdout.Sync()
+				r.writeStdout(kitty.StartAnimation(r.animImageID))
 			}
 			r.lastPlayerState = playerState
 		}
@@ -347,10 +351,10 @@ func (r *CoverRenderer) View(a *model.App, main *model.Main) (view string, lines
 
 			// IMPORTANT: Render static image IMMEDIATELY while animation is being calculated
 			// This avoids a blank cover during the calculation time
-			renderStaticForAnimation(ctx, song, picUrl, coverStartRow, coverStartCol, r.cols, r.rows, r, newAnimID)
+			renderStaticForAnimation(ctx, song, picUrl, coverStartRow, coverStartCol, r.cols, r.rows, r, newAnimID, zIndex)
 
 			// Capture variables for closure
-			go func(ctx context.Context, bgSong structs.Song, bgUrl string, bgRow, bgCol int, bgCols, bgRows int, bgAnimID uint32, oldBgAnimID uint32) {
+			go func(ctx context.Context, bgSong structs.Song, bgUrl string, bgRow, bgCol int, bgCols, bgRows int, bgAnimID uint32, oldBgAnimID uint32, bgZIndex int) {
 				// Fetch image with timeout (derived from cancellable context)
 				fetchCtx, fetchCancel := context.WithTimeout(ctx, 15*time.Second)
 				defer fetchCancel()
@@ -391,8 +395,6 @@ func (r *CoverRenderer) View(a *model.App, main *model.Main) (view string, lines
 
 				// Use ALL available CPU cores
 				numWorkers := max(runtime.NumCPU(), 4) // Minimum 4 workers
-				// Set GOMAXPROCS to ensure all cores are used
-				runtime.GOMAXPROCS(numWorkers)
 
 				// Task and result structures
 				type frameTask struct {
@@ -457,16 +459,36 @@ func (r *CoverRenderer) View(a *model.App, main *model.Main) (view string, lines
 				default:
 				}
 
-				// Transmit frames (skipping frame 0 which is already visible)
+				// Transmit frames (skipping frame 0 which is already visible),
+				// chunked so a cancelled generation stops writing promptly
+				// instead of flushing one multi-megabyte burst, and so the
+				// terminal is not hit with a single huge write.
+				const transmitBatch = 16
 				var frameData strings.Builder
-				for _, seq := range frameSeqs {
-					if seq != "" {
-						frameData.WriteString(seq)
+				for i, seq := range frameSeqs {
+					if seq == "" {
+						continue
 					}
+					if i%transmitBatch == 0 {
+						select {
+						case <-ctx.Done():
+							return
+						default:
+						}
+						if frameData.Len() > 0 {
+							r.writeStdout(frameData.String())
+							frameData.Reset()
+						}
+					}
+					frameData.WriteString(seq)
 				}
 				if frameData.Len() > 0 {
-					_, _ = os.Stdout.WriteString(frameData.String())
-					_ = os.Stdout.Sync()
+					select {
+					case <-ctx.Done():
+						return
+					default:
+					}
+					r.writeStdout(frameData.String())
 				}
 
 				// Assemble minimal sequence for animation playback
@@ -479,7 +501,7 @@ func (r *CoverRenderer) View(a *model.App, main *model.Main) (view string, lines
 				// Placement
 				sb.WriteString("\x1b[s")
 				fmt.Fprintf(&sb, "\x1b[%d;%dH", bgRow, bgCol)
-				sb.WriteString(kitty.PlaceImage(bgAnimID, bgCols, 0, kitty.CoverZIndex))
+				sb.WriteString(kitty.PlaceImage(bgAnimID, bgCols, 0, bgZIndex))
 				sb.WriteString("\x1b[u")
 
 				// Delete OLD ID
@@ -499,7 +521,7 @@ func (r *CoverRenderer) View(a *model.App, main *model.Main) (view string, lines
 					animID:   bgAnimID,
 				}:
 				}
-			}(ctx, song, picUrl, coverStartRow, coverStartCol, r.cols, r.rows, newAnimID, oldAnimID)
+			}(ctx, song, picUrl, coverStartRow, coverStartCol, r.cols, r.rows, newAnimID, oldAnimID, zIndex)
 
 			return "", 0
 		}
@@ -561,6 +583,15 @@ func (r *CoverRenderer) View(a *model.App, main *model.Main) (view string, lines
 	return "", 0
 }
 
+// writeStdout serializes direct terminal writes from the cover renderer
+// (View, animation goroutines, Close) so kitty sequences never interleave.
+func (r *CoverRenderer) writeStdout(s string) {
+	r.writeMu.Lock()
+	defer r.writeMu.Unlock()
+	_, _ = os.Stdout.WriteString(s)
+	_ = os.Stdout.Sync()
+}
+
 // writeToTerminal writes the kitty graphics sequence directly to stdout,
 // bypassing bubbletea's rendering pipeline.
 // deleteOld controls whether to delete existing images first (only needed when changing images).
@@ -586,24 +617,21 @@ func (r *CoverRenderer) writeToTerminal(kittySeq string, startRow, startCol int,
 	// Restore cursor position
 	output += "\x1b[u"
 
-	// Write directly to stdout
-	_, _ = os.Stdout.WriteString(output)
-
-	// Sync to ensure the write is flushed immediately
-	_ = os.Stdout.Sync()
+	r.writeStdout(output)
 }
 
 // renderStaticForAnimation renders a static (non-spinning) version of the cover image
 // immediately while the animation is being calculated in the background.
 // Animation frames will overwrite this static image when ready.
-func renderStaticForAnimation(ctx context.Context, song structs.Song, picUrl string, startRow, startCol, cols, rows int, r *CoverRenderer, animID uint32) {
+func renderStaticForAnimation(ctx context.Context, song structs.Song, picUrl string, startRow, startCol, cols, rows int, r *CoverRenderer, animID uint32, zIndex int) {
 	img, err := r.imageCache.GetImage(ctx, picUrl, cols, rows)
 	if err != nil || img == nil {
 		return
 	}
 
-	// Transmit and display the static image
-	kittySeq, err := kitty.TransmitAndDisplayWithID(img, cols, rows, animID)
+	// Transmit and display the static image, with the z-index captured by the
+	// caller (the global CoverZIndex is mutable and read from this goroutine).
+	kittySeq, err := kitty.TransmitAndDisplayWithIDZ(img, cols, rows, animID, zIndex)
 	if err != nil {
 		return
 	}
@@ -613,8 +641,7 @@ func renderStaticForAnimation(ctx context.Context, song structs.Song, picUrl str
 	output += kittySeq
 	output += "\x1b[u"
 
-	_, _ = os.Stdout.WriteString(output)
-	_ = os.Stdout.Sync()
+	r.writeStdout(output)
 
 	r.mu.Lock()
 	r.currentSongId = song.Id
@@ -677,7 +704,7 @@ func (r *CoverRenderer) ClearDisplayed() {
 		return
 	}
 
-	_, _ = os.Stdout.WriteString(kitty.DeleteAllImages())
+	r.writeStdout(kitty.DeleteAllImages())
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -714,7 +741,7 @@ func (r *CoverRenderer) Close() {
 	}
 
 	// Delete all Kitty graphics images
-	_, _ = os.Stdout.WriteString(kitty.DeleteAllImages())
+	r.writeStdout(kitty.DeleteAllImages())
 
 	// In non-alt-screen mode, we need to be more aggressive with cleanup.
 	// Move cursor to where the image was and clear that area.
@@ -740,12 +767,9 @@ func (r *CoverRenderer) Close() {
 		// Restore cursor position
 		cleanup.WriteString("\x1b[u")
 
-		_, _ = os.Stdout.WriteString(cleanup.String())
+		r.writeStdout(cleanup.String())
 	}
 	r.mu.Unlock()
-
-	// Flush to ensure everything is written before exit
-	_ = os.Stdout.Sync()
 
 	// Small delay to ensure terminal processes the commands
 	// This is especially important in non-alt-screen mode

--- a/internal/ui/kitty/protocol.go
+++ b/internal/ui/kitty/protocol.go
@@ -55,7 +55,15 @@ func TransmitAndDisplay(img image.Image, cols, rows int) (string, error) {
 // TransmitAndDisplayWithID transmits an image with a specific ID.
 // Useful for updating an existing image (animation).
 func TransmitAndDisplayWithID(img image.Image, cols, rows int, imageID uint32) (string, error) {
-	return transmit(img, cols, rows, imageID, "T", 0, CoverZIndex)
+	return TransmitAndDisplayWithIDZ(img, cols, rows, imageID, CoverZIndex)
+}
+
+// TransmitAndDisplayWithIDZ transmits an image with a specific ID and an
+// explicit z-index. Callers that render asynchronously (cover_renderer's
+// animation goroutine) must pass the z-index captured at planning time —
+// reading the mutable global CoverZIndex there races with the render thread.
+func TransmitAndDisplayWithIDZ(img image.Image, cols, rows int, imageID uint32, zIndex int) (string, error) {
+	return transmit(img, cols, rows, imageID, "T", 0, zIndex)
 }
 
 // TransmitImage transmits an image without displaying it.

--- a/internal/ui/mpris_throttle.go
+++ b/internal/ui/mpris_throttle.go
@@ -1,0 +1,36 @@
+package ui
+
+import "time"
+
+// mprisPositionThrottle rate-limits MPRIS Position property broadcasts. The
+// player emits a position every render tick; without throttling, raising the
+// UI frame rate floods the DBus session bus (e.g. 60 updates/sec at 60 FPS).
+//
+// An update is emitted when at least mprisPositionMinInterval has passed since
+// the last one, or immediately when the position jumped by more than
+// mprisPositionJumpMin (e.g. after a seek). Not safe for concurrent use —
+// callers use it from a single goroutine.
+type mprisPositionThrottle struct {
+	lastPos time.Duration
+	lastAt  time.Time
+}
+
+const (
+	mprisPositionMinInterval = 500 * time.Millisecond
+	mprisPositionJumpMin     = 10 * time.Second
+)
+
+// shouldEmit reports whether the new position should be broadcast, updating
+// the throttle state on a hit.
+func (t *mprisPositionThrottle) shouldEmit(pos time.Duration, now time.Time) bool {
+	delta := pos - t.lastPos
+	if delta < 0 {
+		delta = -delta
+	}
+	if now.Sub(t.lastAt) >= mprisPositionMinInterval || delta > mprisPositionJumpMin {
+		t.lastPos = pos
+		t.lastAt = now
+		return true
+	}
+	return false
+}

--- a/internal/ui/mpris_throttle_test.go
+++ b/internal/ui/mpris_throttle_test.go
@@ -1,0 +1,39 @@
+package ui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMprisPositionThrottleRateLimits(t *testing.T) {
+	var throttle mprisPositionThrottle
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// First call always emits.
+	if !throttle.shouldEmit(time.Second, now) {
+		t.Fatal("first call should emit")
+	}
+	// Same second: suppressed.
+	if throttle.shouldEmit(2*time.Second, now.Add(100*time.Millisecond)) {
+		t.Fatal("call within 500ms should be suppressed")
+	}
+	// After 500ms: emitted.
+	if !throttle.shouldEmit(3*time.Second, now.Add(500*time.Millisecond)) {
+		t.Fatal("call after 500ms should emit")
+	}
+}
+
+func TestMprisPositionThrottleEmitsOnJump(t *testing.T) {
+	var throttle mprisPositionThrottle
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	throttle.shouldEmit(time.Second, now)
+	// A seek forward (> 10s jump) bypasses the interval.
+	if !throttle.shouldEmit(30*time.Second, now.Add(50*time.Millisecond)) {
+		t.Fatal("large forward jump should emit immediately")
+	}
+	// A seek backward (> 10s) also bypasses the interval.
+	if !throttle.shouldEmit(5*time.Second, now.Add(60*time.Millisecond)) {
+		t.Fatal("large backward jump should emit immediately")
+	}
+}

--- a/internal/ui/oscilloscope_renderer.go
+++ b/internal/ui/oscilloscope_renderer.go
@@ -171,8 +171,10 @@ func (r *SpectrumRenderer) renderOscilloscopeBlockDual(fullChar, halfChar, empty
 	r.drawOscilloscopeBlockChannel(grid, frame.SamplesR, frame.Count, width, height, connect, 1)
 
 	bg := spectrumAppBg()
+	emptyCell := spectrumEmptyGlyph(emptyChar, bg)
 	var builder strings.Builder
 	builder.Grow((width + 1) * height)
+	var cellBuf []byte
 	for row := 0; row < height; row++ {
 		rowRamp := ramp
 		rowRampDim := rampDim
@@ -184,13 +186,22 @@ func (r *SpectrumRenderer) renderOscilloscopeBlockDual(fullChar, halfChar, empty
 			v := grid[row][col]
 			switch {
 			case v == 3:
-				builder.WriteString(spectrumFgGlyph(fullChar, rowRampDim[col*2], bg))
+				cellBuf = appendSGRFgBg(cellBuf[:0], rowRampDim[col*2], bg)
+				cellBuf = append(cellBuf, fullChar...)
+				cellBuf = append(cellBuf, sgrReset...)
+				builder.Write(cellBuf)
 			case v == 2:
-				builder.WriteString(spectrumFgGlyph(fullChar, rowRamp[col*2], bg))
+				cellBuf = appendSGRFgBg(cellBuf[:0], rowRamp[col*2], bg)
+				cellBuf = append(cellBuf, fullChar...)
+				cellBuf = append(cellBuf, sgrReset...)
+				builder.Write(cellBuf)
 			case v == 1:
-				builder.WriteString(spectrumFgGlyph(halfChar, rowRampDim[col*2], bg))
+				cellBuf = appendSGRFgBg(cellBuf[:0], rowRampDim[col*2], bg)
+				cellBuf = append(cellBuf, halfChar...)
+				cellBuf = append(cellBuf, sgrReset...)
+				builder.Write(cellBuf)
 			default:
-				builder.WriteString(spectrumEmptyGlyph(emptyChar, bg))
+				builder.WriteString(emptyCell)
 			}
 		}
 		builder.WriteByte('\n')
@@ -210,8 +221,10 @@ func (r *SpectrumRenderer) renderOscilloscopeBlockMono(fullChar, halfChar, empty
 	r.drawOscilloscopeBlockChannel(grid, frame.SamplesL, frame.Count, width, height, connect, 2)
 
 	bg := spectrumAppBg()
+	emptyCell := spectrumEmptyGlyph(emptyChar, bg)
 	var builder strings.Builder
 	builder.Grow((width + 1) * height)
+	var cellBuf []byte
 	for row := 0; row < height; row++ {
 		rowRamp := ramp
 		if len(vRamp) > 0 {
@@ -221,11 +234,17 @@ func (r *SpectrumRenderer) renderOscilloscopeBlockMono(fullChar, halfChar, empty
 			v := grid[row][col]
 			switch {
 			case v >= 2:
-				builder.WriteString(spectrumFgGlyph(fullChar, rowRamp[col*2], bg))
+				cellBuf = appendSGRFgBg(cellBuf[:0], rowRamp[col*2], bg)
+				cellBuf = append(cellBuf, fullChar...)
+				cellBuf = append(cellBuf, sgrReset...)
+				builder.Write(cellBuf)
 			case v == 1:
-				builder.WriteString(spectrumFgGlyph(halfChar, rowRamp[col*2], bg))
+				cellBuf = appendSGRFgBg(cellBuf[:0], rowRamp[col*2], bg)
+				cellBuf = append(cellBuf, halfChar...)
+				cellBuf = append(cellBuf, sgrReset...)
+				builder.Write(cellBuf)
 			default:
-				builder.WriteString(spectrumEmptyGlyph(emptyChar, bg))
+				builder.WriteString(emptyCell)
 			}
 		}
 		builder.WriteByte('\n')

--- a/internal/ui/player.go
+++ b/internal/ui/player.go
@@ -86,6 +86,10 @@ type Player struct {
 
 	renderTicker *tickerByPlayer // renderTicker 用于渲染
 
+	// mprisPosThrottle 限制 MPRIS Position 属性更新频率：每个时间 tick 都
+	// 广播会以 UI 帧率灌满 DBus 会话总线（60fps 时 60 次/秒）。
+	mprisPosThrottle mprisPositionThrottle
+
 	player.Player // 播放器
 	reporter      reporter.Service
 }
@@ -152,7 +156,9 @@ func NewPlayer(n *Netease, lyricService *lyric.Service) *Player {
 			case <-ctx.Done():
 				return
 			case duration := <-p.TimeChan():
-				p.stateHandler.SetPosition(p.PassedTime())
+				if pos := p.PassedTime(); p.mprisPosThrottle.shouldEmit(pos, time.Now()) {
+					p.stateHandler.SetPosition(pos)
+				}
 				if duration.Seconds()-p.CurMusic().Duration.Seconds() > 10 {
 					p.NextSong(false)
 				}

--- a/internal/ui/spectrogram_renderer.go
+++ b/internal/ui/spectrogram_renderer.go
@@ -1,10 +1,13 @@
 package ui
 
 import (
+	"image/color"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/anhoder/foxful-cli/model"
+	foxfulStyle "github.com/anhoder/foxful-cli/style"
 	"github.com/anhoder/foxful-cli/util"
 
 	"github.com/go-musicfox/go-musicfox/internal/configs"
@@ -32,11 +35,19 @@ func spectrogramChar(level byte) rune {
 type SpectrogramRenderer struct {
 	provider player.SpectrumProvider
 	history  [][]byte // [row][col]: row=frequency band, col=time
+
+	lastViewTime time.Time        // last View() render timestamp for time-based scrolling
+	scrollFrac   float64          // fractional columns accumulated between renders
+	nowFn        func() time.Time // injectable clock for tests
+
+	rampLastW    int
+	rampStyleGen uint64
+	rampCache    []color.Color
 }
 
 func NewSpectrogramRenderer(state *Player) *SpectrogramRenderer {
 	provider, _ := state.Player.(player.SpectrumProvider)
-	return &SpectrogramRenderer{provider: provider}
+	return &SpectrogramRenderer{provider: provider, nowFn: time.Now}
 }
 
 func (r *SpectrogramRenderer) IsEnabled() bool {
@@ -70,6 +81,62 @@ func (r *SpectrogramRenderer) LineCount(windowHeight, menuBottomRow int) int {
 
 func (*SpectrogramRenderer) Update(tea.Msg, *model.App) {}
 
+// advanceScroll converts elapsed wall time into whole columns to scroll, at
+// speed*5 columns per second (speed is the historical per-frame advance at
+// 5 FPS). Fractional columns accumulate across calls, so the flow rate is
+// independent of the render frame rate. Returns 0 on the first frame or after
+// a long gap (playback paused), keeping the history frozen.
+func (r *SpectrogramRenderer) advanceScroll(elapsed, interval time.Duration, speed, width int) int {
+	if elapsed <= 0 || elapsed > 2*interval {
+		return 0
+	}
+	r.scrollFrac += float64(speed) * 5 * elapsed.Seconds()
+	cols := int(r.scrollFrac)
+	if cols > width {
+		cols = width
+	}
+	r.scrollFrac -= float64(cols)
+	return cols
+}
+
+// scrollAndDraw shifts the history left by scrollCols columns and stamps the
+// current frame into the rightmost scrollCols columns. Extracted from View so
+// it can be unit-tested with a fixed frame and elapsed time.
+func (r *SpectrogramRenderer) scrollAndDraw(frame player.SpectrumFrame, height, width, scrollCols int) {
+	if height <= 0 || width <= 0 {
+		return
+	}
+	if scrollCols < width {
+		for row := 0; row < height; row++ {
+			copy(r.history[row][:width-scrollCols], r.history[row][scrollCols:])
+		}
+	}
+	// Clear the rightmost scrollCols columns.
+	for col := width - scrollCols; col < width; col++ {
+		for row := 0; row < height; row++ {
+			r.history[row][col] = 0
+		}
+	}
+
+	// Draw new data on the rightmost column(s).
+	for col := width - scrollCols; col < width; col++ {
+		for row := 0; row < height; row++ {
+			startBand := row * player.SpectrumBandCount / height
+			endBand := (row + 1) * player.SpectrumBandCount / height
+			if endBand > player.SpectrumBandCount {
+				endBand = player.SpectrumBandCount
+			}
+			level := 0.0
+			for band := startBand; band < endBand; band++ {
+				if frame.Levels[band] > level {
+					level = frame.Levels[band]
+				}
+			}
+			r.history[row][col] = byte(clamp(level, 0, 1) * 255)
+		}
+	}
+}
+
 func (r *SpectrogramRenderer) View(a *model.App, main *model.Main) (view string, lines int) {
 	width := a.WindowWidth()
 	h := r.LineCount(main.EffectiveWindowHeight(a), main.MenuBottomRow())
@@ -86,6 +153,7 @@ func (r *SpectrogramRenderer) View(a *model.App, main *model.Main) (view string,
 		for i := range r.history {
 			r.history[i] = make([]byte, width)
 		}
+		r.scrollFrac = 0
 	}
 
 	speed := configs.AppConfig.Main.Visualizer.EffectiveSpectrogramSpeed()
@@ -96,41 +164,34 @@ func (r *SpectrogramRenderer) View(a *model.App, main *model.Main) (view string,
 		speed = width
 	}
 
-	// Scroll history left by speed columns.
-	if speed < width {
-		for row := 0; row < height; row++ {
-			copy(r.history[row][:width-speed], r.history[row][speed:])
-		}
+	// Scroll is time-based: `speed` means columns per 200ms (the historical
+	// 5 FPS per-frame advance), so the flow rate stays constant regardless of
+	// the configured frame rate. Fractional columns accumulate between frames.
+	now := r.nowFn()
+	elapsed := time.Duration(0)
+	if !r.lastViewTime.IsZero() {
+		elapsed = now.Sub(r.lastViewTime)
+	} else {
+		// First frame: advance one nominal frame interval so spectrum data
+		// appears immediately, matching the historical per-frame behavior.
+		elapsed = configs.AppConfig.Main.FrameRate.Interval()
 	}
-	// Clear the rightmost speed columns.
-	for col := width - speed; col < width; col++ {
-		for row := 0; row < height; row++ {
-			r.history[row][col] = 0
-		}
-	}
+	r.lastViewTime = now
 
-	// Draw new data on rightmost column(s).
-	for col := width - speed; col < width; col++ {
-		for row := 0; row < height; row++ {
-			startBand := row * player.SpectrumBandCount / height
-			endBand := (row + 1) * player.SpectrumBandCount / height
-			if endBand > player.SpectrumBandCount {
-				endBand = player.SpectrumBandCount
-			}
-			level := 0.0
-			for band := startBand; band < endBand; band++ {
-				if frame.Levels[band] > level {
-					level = frame.Levels[band]
-				}
-			}
-			r.history[row][col] = byte(clamp(level, 0, 1) * 255)
-		}
-	}
+	scrollCols := r.advanceScroll(elapsed, configs.AppConfig.Main.FrameRate.Interval(), speed, width)
+	r.scrollAndDraw(frame, height, width, scrollCols)
 
 	// Render to string with color ramp.
-	// TODO: Use theme visualizer color config when integrated
-	start, end := model.GetProgressColor()
-	ramp := util.MakeRamp(start, end, float64(width*2))
+	// The ramp depends only on width and theme colors, so cache it per
+	// (width, style generation) instead of rebuilding it every frame.
+	gen := foxfulStyle.StyleGeneration()
+	if r.rampLastW != width || r.rampStyleGen != gen || len(r.rampCache) == 0 {
+		start, end := model.GetProgressColor()
+		r.rampCache = util.MakeRamp(start, end, float64(width*2))
+		r.rampLastW = width
+		r.rampStyleGen = gen
+	}
+	ramp := r.rampCache
 
 	var builder strings.Builder
 	builder.WriteString(strings.Repeat("\n", SpectrumVerticalPadding))

--- a/internal/ui/spectrogram_renderer_test.go
+++ b/internal/ui/spectrogram_renderer_test.go
@@ -1,0 +1,78 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-musicfox/go-musicfox/internal/player"
+)
+
+func TestSpectrogramAdvanceScrollIsTimeBased(t *testing.T) {
+	// speed=4 means 4 columns per 200ms → 20 columns per second regardless of
+	// the frame rate. Simulate one wall-clock second at 5 FPS and at 60 FPS.
+	const (
+		speed = 4
+		width = 200
+	)
+
+	totalAt5FPS := 0
+	r5 := &SpectrogramRenderer{}
+	for range 5 {
+		totalAt5FPS += r5.advanceScroll(200*time.Millisecond, 200*time.Millisecond, speed, width)
+	}
+
+	totalAt60FPS := 0
+	r60 := &SpectrogramRenderer{}
+	for range 60 {
+		totalAt60FPS += r60.advanceScroll(16667*time.Microsecond, 16*time.Millisecond, speed, width)
+	}
+
+	if totalAt5FPS != 20 {
+		t.Fatalf("scrolled %d columns in 1s at 5 FPS, want 20", totalAt5FPS)
+	}
+	if totalAt60FPS != 20 {
+		t.Fatalf("scrolled %d columns in 1s at 60 FPS, want 20", totalAt60FPS)
+	}
+}
+
+func TestSpectrogramAdvanceScrollFreezesOnLongGap(t *testing.T) {
+	r := &SpectrogramRenderer{}
+	if got := r.advanceScroll(10*time.Second, 200*time.Millisecond, 4, 200); got != 0 {
+		t.Fatalf("scrolled %d columns after a 10s pause, want 0 (history frozen)", got)
+	}
+}
+
+func TestSpectrogramAdvanceScrollCapsAtWidth(t *testing.T) {
+	r := &SpectrogramRenderer{}
+	if got := r.advanceScroll(200*time.Millisecond, 200*time.Millisecond, 4, 3); got != 3 {
+		t.Fatalf("scrolled %d columns, want capped at width 3", got)
+	}
+}
+
+func TestSpectrogramScrollAndDrawMovesHistory(t *testing.T) {
+	r := &SpectrogramRenderer{}
+	height, width := 2, 8
+	// View allocates the history buffer before scrolling; mirror that here.
+	r.history = make([][]byte, height)
+	for i := range r.history {
+		r.history[i] = make([]byte, width)
+	}
+
+	// First frame: stamp data into the last column.
+	frame := player.SpectrumFrame{}
+	frame.Levels[0] = 1
+	r.scrollAndDraw(frame, height, width, 1)
+	if r.history[0][width-1] == 0 {
+		t.Fatal("first frame was not stamped into the rightmost column")
+	}
+
+	// A full-width scroll clears everything and stamps the new frame at the right.
+	r.scrollAndDraw(player.SpectrumFrame{}, height, width, width)
+	for row := 0; row < height; row++ {
+		for col := 0; col < width-1; col++ {
+			if r.history[row][col] != 0 {
+				t.Fatalf("history[%d][%d] = %d, want 0 after full-width scroll", row, col, r.history[row][col])
+			}
+		}
+	}
+}

--- a/internal/ui/spectrum_perf_bench_test.go
+++ b/internal/ui/spectrum_perf_bench_test.go
@@ -1,0 +1,30 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/go-musicfox/go-musicfox/internal/configs"
+	"github.com/go-musicfox/go-musicfox/internal/player"
+)
+
+func benchSpectrumRender(b *testing.B, style string) {
+	previousConfig := configs.AppConfig
+	configs.AppConfig = &configs.Config{}
+	configs.AppConfig.Main.Visualizer.Enable = true
+	configs.AppConfig.Main.Visualizer.Style = style
+	b.Cleanup(func() { configs.AppConfig = previousConfig })
+
+	r := &SpectrumRenderer{}
+	frame := player.SpectrumFrame{}
+	for i := range frame.LevelsL {
+		frame.LevelsL[i] = float64(i) / player.SpectrumBandCount
+		frame.LevelsR[i] = 1 - float64(i)/player.SpectrumBandCount
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.render(frame, 200, 20)
+	}
+}
+
+func BenchmarkSpectrumRenderLine200x20(b *testing.B) { benchSpectrumRender(b, "line") }
+func BenchmarkSpectrumRenderBar200x20(b *testing.B)  { benchSpectrumRender(b, "bar") }

--- a/internal/ui/spectrum_renderer.go
+++ b/internal/ui/spectrum_renderer.go
@@ -3,7 +3,9 @@ package ui
 import (
 	"image/color"
 	"math"
+	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -169,10 +171,13 @@ type SpectrumRenderer struct {
 	provider             player.SpectrumProvider
 	progressLastWidth    float64
 	progressRamp         []color.Color
+	progressStyleGen     uint64 // style.StyleGeneration() at last ramp build
 	progressDimLastWidth float64
 	progressDimRamp      []color.Color
+	progressDimStyleGen  uint64
 	vertLastWidth        float64
 	vertLastHeight       int
+	vertRowRampsStyleGen uint64
 	vertRowRamps         [][]color.Color
 	brailleGridLCache    [][]byte
 	brailleGridRCache    [][]byte
@@ -180,6 +185,27 @@ type SpectrumRenderer struct {
 	brailleCacheW        int
 	brailleCacheH        int
 	phaseMask            []float64 // per-column phase correlation, set per frame when SpectrumPhaseDiff enabled
+
+	// vertBrailleRamps/vertBrailleRampsDim cache: per (width, height, style
+	// generation), shared by all braille/block renderers. The result depends
+	// only on dimensions and theme colors, never on frame data — recomputing
+	// it every frame was the dominant per-frame cost at high frame rates.
+	vertRampCacheW, vertRampCacheH int
+	vertRampCacheGen               uint64
+	vertRampCache                  [][]color.Color // plain (L channel)
+	vertRampDimCache               [][]color.Color // dim (R channel)
+
+	// resolvedBarRamps cache: final per-row ramps for bar styles after
+	// vertical/horizontal gradient combination.
+	resolvedRampCacheW, resolvedRampCacheH int
+	resolvedRampCacheGen                   uint64
+	resolvedRampFlags                      uint8 // bit0: vertical, bit1: horizontal
+	resolvedRowRamps                       [][]color.Color
+
+	// horizontalColor cache: per-row color of the horizontal gradient.
+	horizColorsCacheH   int
+	horizColorsCacheGen uint64
+	horizColors         []color.Color
 }
 
 func NewSpectrumRenderer(state *Player) *SpectrumRenderer {
@@ -374,32 +400,14 @@ func (r *SpectrumRenderer) renderBarBottom(frame player.SpectrumFrame, width, he
 	cfg := configs.AppConfig.Main.Visualizer
 	halfBlock, fullBlock, emptyBlock := cfg.BarCharacters()
 	progressRamp := r.ramp(width)
-	vertEnabled := cfg.BarVerticalGradient
-	horizEnabled := cfg.BarHorizontalGradient
-
-	var rowRamps [][]color.Color
-	if vertEnabled {
-		rowRamps = r.rowRamps(width, height, true)
-	}
+	resolved := r.resolvedBarRamps(width, height, cfg.BarVerticalGradient, cfg.BarHorizontalGradient)
 
 	var builder strings.Builder
 	builder.Grow((width + 1) * height)
 	for row := 0; row < height; row++ {
 		ramp := progressRamp
-		if len(rowRamps) > 0 {
-			ramp = rowRamps[row]
-		}
-
-		// Horizontal gradient: compute per-row color or blend with vertical ramp
-		if horizEnabled {
-			horizColor := r.horizontalColor(row, height)
-			if !vertEnabled {
-				// Only horizontal: solid-color ramp
-				ramp = r.horizontalBarRamp(row, width, height)
-			} else {
-				// Both: blend horizontal into vertical ramp
-				ramp = blendRamps(ramp, horizColor)
-			}
+		if len(resolved) > 0 {
+			ramp = resolved[row]
 		}
 
 		level := spectrumRowLevel(frame, row, height)
@@ -426,31 +434,15 @@ func (r *SpectrumRenderer) renderMirror(frame player.SpectrumFrame, width, heigh
 	cfg := configs.AppConfig.Main.Visualizer
 	halfBlock, fullBlock, emptyBlock := cfg.MirrorBarCharacters()
 	progressRamp := r.ramp(width)
-	vertEnabled := cfg.BarVerticalGradient
-	horizEnabled := cfg.BarHorizontalGradient
-
-	var rowRamps [][]color.Color
-	if vertEnabled {
-		rowRamps = r.rowRamps(width, height, true)
-	}
+	resolved := r.resolvedBarRamps(width, height, cfg.BarVerticalGradient, cfg.BarHorizontalGradient)
 
 	mono := cfg.IsMono()
 	var builder strings.Builder
 	builder.Grow((width + 1) * height)
 	for row := 0; row < height; row++ {
 		ramp := progressRamp
-		if len(rowRamps) > 0 {
-			ramp = rowRamps[row]
-		}
-
-		// Horizontal gradient: compute per-row color or blend with vertical ramp
-		if horizEnabled {
-			horizColor := r.horizontalColor(row, height)
-			if !vertEnabled {
-				ramp = r.horizontalBarRamp(row, width, height)
-			} else {
-				ramp = blendRamps(ramp, horizColor)
-			}
+		if len(resolved) > 0 {
+			ramp = resolved[row]
 		}
 
 		var levelL, levelR float64
@@ -533,8 +525,11 @@ func (r *SpectrumRenderer) renderBrailleGridDual(gridL, gridR [][]byte, width, h
 	}
 
 	bg := spectrumAppBg()
+	emptyCell := spectrumEmptyGlyph(" ", bg)
 	var builder strings.Builder
 	builder.Grow((width + 1) * height)
+	// cellBuf is reused across cells so filled cells do not allocate per cell.
+	var cellBuf []byte
 	for row := 0; row < height; row++ {
 		rowRamp := ramp
 		rowRampDim := rampDim
@@ -547,7 +542,7 @@ func (r *SpectrumRenderer) renderBrailleGridDual(gridL, gridR [][]byte, width, h
 			dotsR := gridR[row][col]
 			dots := dotsL | dotsR
 			if dots == 0 {
-				builder.WriteString(spectrumEmptyGlyph(" ", bg))
+				builder.WriteString(emptyCell)
 				continue
 			}
 			c := rowRamp[col*2]
@@ -558,7 +553,10 @@ func (r *SpectrumRenderer) renderBrailleGridDual(gridL, gridR [][]byte, width, h
 			if len(r.phaseMask) > 0 && hasR && col < len(r.phaseMask) {
 				c = blendPhaseColor(c, r.phaseMask[col])
 			}
-			builder.WriteString(spectrumFgGlyph(string(brailleCell(dots)), c, bg))
+			cellBuf = appendSGRFgBg(cellBuf[:0], c, bg)
+			cellBuf = utf8.AppendRune(cellBuf, brailleCell(dots))
+			cellBuf = append(cellBuf, sgrReset...)
+			builder.Write(cellBuf)
 		}
 		builder.WriteByte('\n')
 	}
@@ -568,68 +566,63 @@ func (r *SpectrumRenderer) renderBrailleGridDual(gridL, gridR [][]byte, width, h
 // vertBrailleRamps returns per-row ramps blending the horizontal gradient
 // with a top→bottom brightness shift. Top rows are slightly darker.
 func (r *SpectrumRenderer) vertBrailleRamps(width, height int) [][]color.Color {
-	if height <= 1 {
-		return nil
+	r.ensureVertRamps(width, height)
+	return r.vertRampCache
+}
+
+// vertBrailleRampsDim applies the same vertical gradient to the shifted ramp.
+// The ramp itself is r.rampDim(width); the base parameter is kept for call
+// sites that already hold it.
+func (r *SpectrumRenderer) vertBrailleRampsDim(width, height int, _ []color.Color) [][]color.Color {
+	r.ensureVertRamps(width, height)
+	return r.vertRampDimCache
+}
+
+// ensureVertRamps computes both the plain and dim vertical ramps at most once
+// per (width, height, style generation). The result depends only on the
+// window dimensions and theme colors, so it is shared by every renderer and
+// reused across frames.
+func (r *SpectrumRenderer) ensureVertRamps(width, height int) {
+	gen := foxfulStyle.StyleGeneration()
+	if r.vertRampCacheW == width && r.vertRampCacheH == height && r.vertRampCacheGen == gen {
+		return
 	}
-	base := r.ramp(width)
+	r.vertRampCache, r.vertRampDimCache = nil, nil
+	r.vertRampCacheW, r.vertRampCacheH, r.vertRampCacheGen = width, height, gen
+	if height <= 1 {
+		return
+	}
 	vertBgHex := configs.GetSpectrumVerticalBg()
 	if vertBgHex == "" {
-		// Transparent background — skip vertical blend, return uniform rows
-		ramps := make([][]color.Color, height)
-		for row := range height {
-			rowRamp := make([]color.Color, len(base))
-			copy(rowRamp, base)
-			ramps[row] = rowRamp
-		}
-		return ramps
+		// Transparent background: callers fall back to the plain ramp, which
+		// is visually identical to the uniform per-row copies the old code
+		// produced.
+		return
 	}
 	black, _ := colorful.Hex(vertBgHex)
 
-	ramps := make([][]color.Color, height)
+	base := r.ramp(width)
+	dimBase := r.rampDim(width)
+	plain := make([][]color.Color, height)
+	dim := make([][]color.Color, height)
 	for row := range height {
 		// 0.0=top(dark) → 1.0=bottom(bright)
 		t := float64(row) / float64(height-1)
 		blend := 0.35 * (1.0 - t) // top blends 35% black, bottom 0%
-		rowRamp := make([]color.Color, len(base))
+		plainRow := make([]color.Color, len(base))
+		dimRow := make([]color.Color, len(dimBase))
 		for i, c := range base {
 			h, _ := colorful.MakeColor(c)
-			rowRamp[i] = h.BlendLuv(black, blend)
+			plainRow[i] = h.BlendLuv(black, blend)
 		}
-		ramps[row] = rowRamp
-	}
-	return ramps
-}
-
-// vertBrailleRampsDim applies the same vertical gradient to the shifted ramp.
-func (r *SpectrumRenderer) vertBrailleRampsDim(width, height int, base []color.Color) [][]color.Color {
-	if height <= 1 {
-		return nil
-	}
-	vertBgHex := configs.GetSpectrumVerticalBg()
-	if vertBgHex == "" {
-		// Transparent background — skip vertical blend, return uniform rows
-		ramps := make([][]color.Color, height)
-		for row := range height {
-			rowRamp := make([]color.Color, len(base))
-			copy(rowRamp, base)
-			ramps[row] = rowRamp
-		}
-		return ramps
-	}
-	black, _ := colorful.Hex(vertBgHex)
-
-	ramps := make([][]color.Color, height)
-	for row := range height {
-		t := float64(row) / float64(height-1)
-		blend := 0.35 * (1.0 - t)
-		rowRamp := make([]color.Color, len(base))
-		for i, c := range base {
+		for i, c := range dimBase {
 			h, _ := colorful.MakeColor(c)
-			rowRamp[i] = h.BlendLuv(black, blend)
+			dimRow[i] = h.BlendLuv(black, blend)
 		}
-		ramps[row] = rowRamp
+		plain[row] = plainRow
+		dim[row] = dimRow
 	}
-	return ramps
+	r.vertRampCache, r.vertRampDimCache = plain, dim
 }
 
 // --- Style: line/dot braille mono ---
@@ -654,8 +647,10 @@ func (r *SpectrumRenderer) renderBrailleGridMono(grid [][]byte, width, height in
 	vRamp := r.vertBrailleRamps(width, height)
 
 	bg := spectrumAppBg()
+	emptyCell := spectrumEmptyGlyph(" ", bg)
 	var builder strings.Builder
 	builder.Grow((width + 1) * height)
+	var cellBuf []byte
 	for row := 0; row < height; row++ {
 		rowRamp := ramp
 		if len(vRamp) > 0 {
@@ -664,11 +659,14 @@ func (r *SpectrumRenderer) renderBrailleGridMono(grid [][]byte, width, height in
 		for col := 0; col < width; col++ {
 			dots := grid[row][col]
 			if dots == 0 {
-				builder.WriteString(spectrumEmptyGlyph(" ", bg))
+				builder.WriteString(emptyCell)
 				continue
 			}
 			c := rowRamp[col*2]
-			builder.WriteString(spectrumFgGlyph(string(brailleCell(dots)), c, bg))
+			cellBuf = appendSGRFgBg(cellBuf[:0], c, bg)
+			cellBuf = utf8.AppendRune(cellBuf, brailleCell(dots))
+			cellBuf = append(cellBuf, sgrReset...)
+			builder.Write(cellBuf)
 		}
 		builder.WriteByte('\n')
 	}
@@ -727,8 +725,10 @@ func (r *SpectrumRenderer) renderBlockDual(fullChar, halfChar, emptyChar string,
 	}
 
 	bg := spectrumAppBg()
+	emptyCell := spectrumEmptyGlyph(emptyChar, bg)
 	var builder strings.Builder
 	builder.Grow((width + 1) * height)
+	var cellBuf []byte
 	for row := 0; row < height; row++ {
 		rowRamp := ramp
 		rowRampDim := rampDim
@@ -744,17 +744,26 @@ func (r *SpectrumRenderer) renderBlockDual(fullChar, halfChar, emptyChar string,
 				if len(r.phaseMask) > 0 && hasR && col < len(r.phaseMask) {
 					c = blendPhaseColor(c, r.phaseMask[col])
 				}
-				builder.WriteString(spectrumFgGlyph(fullChar, c, bg))
+				cellBuf = appendSGRFgBg(cellBuf[:0], c, bg)
+				cellBuf = append(cellBuf, fullChar...)
+				cellBuf = append(cellBuf, sgrReset...)
+				builder.Write(cellBuf)
 			case v == 2:
-				builder.WriteString(spectrumFgGlyph(fullChar, rowRamp[col*2], bg))
+				cellBuf = appendSGRFgBg(cellBuf[:0], rowRamp[col*2], bg)
+				cellBuf = append(cellBuf, fullChar...)
+				cellBuf = append(cellBuf, sgrReset...)
+				builder.Write(cellBuf)
 			case v == 1:
 				c := rowRampDim[col*2]
 				if len(r.phaseMask) > 0 && hasR && col < len(r.phaseMask) {
 					c = blendPhaseColor(c, r.phaseMask[col])
 				}
-				builder.WriteString(spectrumFgGlyph(halfChar, c, bg))
+				cellBuf = appendSGRFgBg(cellBuf[:0], c, bg)
+				cellBuf = append(cellBuf, halfChar...)
+				cellBuf = append(cellBuf, sgrReset...)
+				builder.Write(cellBuf)
 			default:
-				builder.WriteString(spectrumEmptyGlyph(emptyChar, bg))
+				builder.WriteString(emptyCell)
 			}
 		}
 		builder.WriteByte('\n')
@@ -774,8 +783,10 @@ func (r *SpectrumRenderer) renderBlockMono(fullChar, halfChar, emptyChar string,
 	drawBlockChannel(grid, levels, width, height, connect, 2)
 
 	bg := spectrumAppBg()
+	emptyCell := spectrumEmptyGlyph(emptyChar, bg)
 	var builder strings.Builder
 	builder.Grow((width + 1) * height)
+	var cellBuf []byte
 	for row := 0; row < height; row++ {
 		rowRamp := ramp
 		if len(vRamp) > 0 {
@@ -785,11 +796,17 @@ func (r *SpectrumRenderer) renderBlockMono(fullChar, halfChar, emptyChar string,
 			v := grid[row][col]
 			switch {
 			case v >= 2:
-				builder.WriteString(spectrumFgGlyph(fullChar, rowRamp[col*2], bg))
+				cellBuf = appendSGRFgBg(cellBuf[:0], rowRamp[col*2], bg)
+				cellBuf = append(cellBuf, fullChar...)
+				cellBuf = append(cellBuf, sgrReset...)
+				builder.Write(cellBuf)
 			case v == 1:
-				builder.WriteString(spectrumFgGlyph(halfChar, rowRamp[col*2], bg))
+				cellBuf = appendSGRFgBg(cellBuf[:0], rowRamp[col*2], bg)
+				cellBuf = append(cellBuf, halfChar...)
+				cellBuf = append(cellBuf, sgrReset...)
+				builder.Write(cellBuf)
 			default:
-				builder.WriteString(spectrumEmptyGlyph(emptyChar, bg))
+				builder.WriteString(emptyCell)
 			}
 		}
 		builder.WriteByte('\n')
@@ -889,7 +906,8 @@ func drawGridLineMaskAt(grid [][]byte, x1, y1, x2, y2 int, priority byte) {
 // a vibrant, distinct color that contrasts clearly with the L channel.
 // Cached: when width matches the previous call, the cached ramp is returned.
 func (r *SpectrumRenderer) rampDim(width int) []color.Color {
-	if r.progressDimLastWidth == float64(width) && len(r.progressDimRamp) > 0 {
+	gen := foxfulStyle.StyleGeneration()
+	if r.progressDimLastWidth == float64(width) && r.progressDimStyleGen == gen && len(r.progressDimRamp) > 0 {
 		return r.progressDimRamp
 	}
 	base := r.ramp(width)
@@ -903,6 +921,7 @@ func (r *SpectrumRenderer) rampDim(width int) []color.Color {
 	}
 	r.progressDimRamp = shifted
 	r.progressDimLastWidth = float64(width)
+	r.progressDimStyleGen = gen
 	return shifted
 }
 
@@ -1304,12 +1323,17 @@ func hasSignal(frame player.SpectrumFrame) bool {
 }
 
 func (r *SpectrumRenderer) ramp(width int) []color.Color {
-	// TODO: Use theme visualizer color config via configs.AppColorConfig.ResolveVisualizerColors() when integrated
-	if r.progressLastWidth != float64(width) || len(r.progressRamp) == 0 {
-		start, end := model.GetProgressColor()
-		r.progressRamp = util.MakeRamp(start, end, float64(width*2))
-		r.progressLastWidth = float64(width)
+	// The ramp depends on theme colors; the style generation invalidates the
+	// cache on theme switches so stale colors are never replayed.
+	gen := foxfulStyle.StyleGeneration()
+	if r.progressLastWidth == float64(width) && r.progressStyleGen == gen && len(r.progressRamp) > 0 {
+		return r.progressRamp
 	}
+	// TODO: Use theme visualizer color config via configs.AppColorConfig.ResolveVisualizerColors() when integrated
+	start, end := model.GetProgressColor()
+	r.progressRamp = util.MakeRamp(start, end, float64(width*2))
+	r.progressLastWidth = float64(width)
+	r.progressStyleGen = gen
 	return r.progressRamp
 }
 
@@ -1317,7 +1341,8 @@ func (r *SpectrumRenderer) rowRamps(width, height int, enabled bool) [][]color.C
 	if !enabled {
 		return nil
 	}
-	if r.vertLastWidth == float64(width) && r.vertLastHeight == height && len(r.vertRowRamps) > 0 {
+	gen := foxfulStyle.StyleGeneration()
+	if r.vertLastWidth == float64(width) && r.vertLastHeight == height && r.vertRowRampsStyleGen == gen && len(r.vertRowRamps) > 0 {
 		return r.vertRowRamps
 	}
 	if height <= 1 {
@@ -1345,29 +1370,83 @@ func (r *SpectrumRenderer) rowRamps(width, height int, enabled bool) [][]color.C
 	}
 	r.vertLastWidth = float64(width)
 	r.vertLastHeight = height
+	r.vertRowRampsStyleGen = gen
 	return r.vertRowRamps
+}
+
+// resolvedBarRamps returns the final per-row ramp used by bar styles after
+// vertical/horizontal gradient combination, cached per (width, height, style
+// generation, gradient flags). Returns nil when no gradient is enabled — the
+// caller falls back to the plain progress ramp.
+func (r *SpectrumRenderer) resolvedBarRamps(width, height int, vertEnabled, horizEnabled bool) [][]color.Color {
+	if !vertEnabled && !horizEnabled {
+		return nil
+	}
+	var flags uint8
+	if vertEnabled {
+		flags |= 1
+	}
+	if horizEnabled {
+		flags |= 2
+	}
+	gen := foxfulStyle.StyleGeneration()
+	if r.resolvedRampCacheW == width && r.resolvedRampCacheH == height && r.resolvedRampCacheGen == gen && r.resolvedRampFlags == flags {
+		return r.resolvedRowRamps
+	}
+
+	rowRamps := r.rowRamps(width, height, vertEnabled)
+	progressRamp := r.ramp(width)
+	resolved := make([][]color.Color, height)
+	for row := 0; row < height; row++ {
+		ramp := progressRamp
+		if len(rowRamps) > 0 {
+			ramp = rowRamps[row]
+		}
+		if horizEnabled {
+			horizColor := r.horizontalColor(row, height)
+			if !vertEnabled {
+				// Uniform-color ramp per row.
+				uniform := make([]color.Color, len(progressRamp))
+				for i := range uniform {
+					uniform[i] = horizColor
+				}
+				ramp = uniform
+			} else {
+				ramp = blendRamps(ramp, horizColor)
+			}
+		}
+		resolved[row] = ramp
+	}
+	r.resolvedRowRamps = resolved
+	r.resolvedRampCacheW, r.resolvedRampCacheH = width, height
+	r.resolvedRampCacheGen, r.resolvedRampFlags = gen, flags
+	return resolved
+}
+
+// ensureHorizontalColors precomputes the per-row horizontal gradient colors,
+// cached per (height, style generation).
+func (r *SpectrumRenderer) ensureHorizontalColors(height int) {
+	gen := foxfulStyle.StyleGeneration()
+	if r.horizColorsCacheH == height && r.horizColorsCacheGen == gen && len(r.horizColors) > 0 {
+		return
+	}
+	start, end := model.GetProgressColor()
+	cStart, _ := colorful.Hex(start)
+	cEnd, _ := colorful.Hex(end)
+	colors := make([]color.Color, max(height, 1))
+	for row := range colors {
+		t := float64(row) / float64(max(height-1, 1))
+		colors[row] = cStart.BlendLuv(cEnd, t)
+	}
+	r.horizColors = colors
+	r.horizColorsCacheH, r.horizColorsCacheGen = height, gen
 }
 
 // horizontalColor returns a single color interpolated between theme start/end
 // based on the row position within the total height.
 func (r *SpectrumRenderer) horizontalColor(row, height int) color.Color {
-	start, end := model.GetProgressColor()
-	cStart, _ := colorful.Hex(start)
-	cEnd, _ := colorful.Hex(end)
-	t := float64(row) / float64(max(height-1, 1))
-	return cStart.BlendLuv(cEnd, t)
-}
-
-// horizontalBarRamp returns a uniform-color ramp (all entries the same color)
-// for a given row, derived from the horizontal gradient position.
-func (r *SpectrumRenderer) horizontalBarRamp(row, width, height int) []color.Color {
-	c := r.horizontalColor(row, height)
-	rampLen := width * 2
-	result := make([]color.Color, rampLen)
-	for i := range result {
-		result[i] = c
-	}
-	return result
+	r.ensureHorizontalColors(height)
+	return r.horizColors[row]
 }
 
 // blendRamps blends a horizontal color into each entry of a row ramp at 50%.
@@ -1379,6 +1458,45 @@ func blendRamps(rowRamp []color.Color, horizColor color.Color) []color.Color {
 		result[i] = hColor.BlendLuv(horizColorful, 0.5)
 	}
 	return result
+}
+
+// sgrReset is the SGR reset emitted after every styled cell, matching
+// lipgloss's rendering ("\x1b[m").
+var sgrReset = []byte("\x1b[m")
+
+// appendSGRFgBg appends the SGR prefix for fg over bg, in the same combined
+// truecolor format lipgloss v2 emits ("\x1b[38;2;R;G;B;48;2;R;G;Bm"). Either
+// color may be nil; both nil yields no escape sequence at all.
+func appendSGRFgBg(buf []byte, fg, bg color.Color) []byte {
+	if fg == nil && bg == nil {
+		return buf
+	}
+	buf = append(buf, '\x1b', '[')
+	if fg != nil {
+		buf = appendSGRColor(buf, '3', fg)
+	}
+	if bg != nil {
+		if fg != nil {
+			buf = append(buf, ';')
+		}
+		buf = appendSGRColor(buf, '4', bg)
+	}
+	buf = append(buf, 'm')
+	return buf
+}
+
+// appendSGRColor appends a "38;2;R;G;B" (mode '3') or "48;2;R;G;B" (mode '4')
+// truecolor prefix. Channel values are the 16-bit RGBA values scaled to 8-bit,
+// identical to what lipgloss emits on a truecolor profile.
+func appendSGRColor(buf []byte, mode byte, c color.Color) []byte {
+	r, g, b, _ := c.RGBA()
+	buf = append(buf, mode, '8', ';', '2', ';')
+	buf = strconv.AppendInt(buf, int64(r>>8), 10)
+	buf = append(buf, ';')
+	buf = strconv.AppendInt(buf, int64(g>>8), 10)
+	buf = append(buf, ';')
+	buf = strconv.AppendInt(buf, int64(b>>8), 10)
+	return buf
 }
 
 func spectrumHalfBlockStyle(foreground, background color.Color) lipgloss.Style {
@@ -1394,21 +1512,29 @@ func spectrumAppBg() color.Color {
 
 // spectrumFgGlyph renders a single foreground-colored glyph, painting it over
 // bg when non-nil so the glyph cell never stays transparent (which would reveal
-// content drawn beneath the TUI, e.g. the cover image).
+// content drawn beneath the TUI, e.g. the cover image). Uses raw SGR sequences
+// instead of per-cell lipgloss styles, which were the dominant per-frame
+// allocation at high frame rates.
 func spectrumFgGlyph(char string, fg, bg color.Color) string {
-	if bg != nil {
-		return util.SetFgBgStyle(char, fg, bg)
+	buf := appendSGRFgBg(nil, fg, bg)
+	if buf == nil {
+		return char
 	}
-	return util.SetFgStyle(char, fg)
+	buf = append(buf, char...)
+	buf = append(buf, sgrReset...)
+	return string(buf)
 }
 
 // spectrumEmptyGlyph renders an empty/plain glyph, painting it over bg when
 // non-nil so empty cells carry the app background too.
 func spectrumEmptyGlyph(char string, bg color.Color) string {
-	if bg != nil {
-		return foxfulStyle.CurrentStyleSet().AppBackground.Render(char)
+	if bg == nil {
+		return char
 	}
-	return char
+	buf := appendSGRFgBg(nil, nil, bg)
+	buf = append(buf, char...)
+	buf = append(buf, sgrReset...)
+	return string(buf)
 }
 
 func spectrumRowLevel(frame player.SpectrumFrame, row, height int) float64 {

--- a/internal/ui/spectrum_renderer.go
+++ b/internal/ui/spectrum_renderer.go
@@ -1464,19 +1464,36 @@ func blendRamps(rowRamp []color.Color, horizColor color.Color) []color.Color {
 // lipgloss's rendering ("\x1b[m").
 var sgrReset = []byte("\x1b[m")
 
+// sgrWorthEmitting reports whether a color produces a channel in the escape
+// sequence: nil colors and lipgloss.NoColor ("absence of color", the sentinel
+// for unconfigured theme backgrounds) are both skipped, exactly like lipgloss
+// does when rendering a style.
+func sgrWorthEmitting(c color.Color) bool {
+	if c == nil {
+		return false
+	}
+	if _, isNoColor := c.(lipgloss.NoColor); isNoColor {
+		return false
+	}
+	return true
+}
+
 // appendSGRFgBg appends the SGR prefix for fg over bg, in the same combined
 // truecolor format lipgloss v2 emits ("\x1b[38;2;R;G;B;48;2;R;G;Bm"). Either
-// color may be nil; both nil yields no escape sequence at all.
+// color may be nil or NoColor; neither emitting yields no escape sequence at
+// all (the returned buffer is unchanged).
 func appendSGRFgBg(buf []byte, fg, bg color.Color) []byte {
-	if fg == nil && bg == nil {
+	fgOn := sgrWorthEmitting(fg)
+	bgOn := sgrWorthEmitting(bg)
+	if !fgOn && !bgOn {
 		return buf
 	}
 	buf = append(buf, '\x1b', '[')
-	if fg != nil {
+	if fgOn {
 		buf = appendSGRColor(buf, '3', fg)
 	}
-	if bg != nil {
-		if fg != nil {
+	if bgOn {
+		if fgOn {
 			buf = append(buf, ';')
 		}
 		buf = appendSGRColor(buf, '4', bg)
@@ -1489,6 +1506,17 @@ func appendSGRFgBg(buf []byte, fg, bg color.Color) []byte {
 // truecolor prefix. Channel values are the 16-bit RGBA values scaled to 8-bit,
 // identical to what lipgloss emits on a truecolor profile.
 func appendSGRColor(buf []byte, mode byte, c color.Color) []byte {
+	if c == nil {
+		return buf
+	}
+	// lipgloss.NoColor ("absence of color") must be detected by type assertion:
+	// its RGBA() returns (0,0,0,65535), indistinguishable from a legitimate
+	// black background. lipgloss skips NoColor channels entirely; so must we,
+	// otherwise transparent themes (Default, Transparent) render the whole
+	// visualizer as an opaque black block.
+	if _, isNoColor := c.(lipgloss.NoColor); isNoColor {
+		return buf
+	}
 	r, g, b, _ := c.RGBA()
 	buf = append(buf, mode, '8', ';', '2', ';')
 	buf = strconv.AppendInt(buf, int64(r>>8), 10)
@@ -1528,10 +1556,10 @@ func spectrumFgGlyph(char string, fg, bg color.Color) string {
 // spectrumEmptyGlyph renders an empty/plain glyph, painting it over bg when
 // non-nil so empty cells carry the app background too.
 func spectrumEmptyGlyph(char string, bg color.Color) string {
-	if bg == nil {
+	buf := appendSGRFgBg(nil, nil, bg)
+	if buf == nil {
 		return char
 	}
-	buf := appendSGRFgBg(nil, nil, bg)
 	buf = append(buf, char...)
 	buf = append(buf, sgrReset...)
 	return string(buf)

--- a/internal/ui/spectrum_renderer_test.go
+++ b/internal/ui/spectrum_renderer_test.go
@@ -628,6 +628,15 @@ func TestAppendSGRFgBgMatchesLipgloss(t *testing.T) {
 		{"bg only", nil, bg},
 		{"fg and bg", fg, bg},
 		{"neither", nil, nil},
+		// NoColor ("absence of color") must be skipped like lipgloss does;
+		// its RGBA() is (0,0,0,65535) — indistinguishable from black, so the
+		// SGR builder must detect it by type. Otherwise transparent themes
+		// (Default, Transparent) paint the whole visualizer opaque black.
+		{"fg NoColor", lipgloss.NoColor{}, nil},
+		{"bg NoColor", nil, lipgloss.NoColor{}},
+		{"both NoColor", lipgloss.NoColor{}, lipgloss.NoColor{}},
+		{"fg NoColor over bg", lipgloss.NoColor{}, bg},
+		{"fg over bg NoColor", fg, lipgloss.NoColor{}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -645,6 +654,11 @@ func TestAppendSGRFgBgMatchesLipgloss(t *testing.T) {
 			}
 			if manual != lipglossOut {
 				t.Fatalf("manual SGR %q != lipgloss %q", manual, lipglossOut)
+			}
+			// A NoColor background must never degrade to an opaque black
+			// "48;2;0;0;0" escape — that's the regression this test guards.
+			if strings.Contains(manual, "48;2;0;0;0") {
+				t.Fatalf("NoColor background rendered as opaque black: %q", manual)
 			}
 		})
 	}

--- a/internal/ui/spectrum_renderer_test.go
+++ b/internal/ui/spectrum_renderer_test.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 	foxfulStyle "github.com/anhoder/foxful-cli/style"
+	"github.com/anhoder/foxful-cli/util"
 
 	"github.com/go-musicfox/go-musicfox/internal/configs"
 	"github.com/go-musicfox/go-musicfox/internal/player"
@@ -167,7 +168,10 @@ func TestSpectrumEmptyCellsHaveNoStyle(t *testing.T) {
 	for index := range ramp {
 		ramp[index] = color.RGBA{R: 0x12, G: 0x34, B: 0x56, A: 0xff}
 	}
-	bar := renderSpectrumBar(1.0/16, 8, ramp, '▌', '█', ' ')
+	// Strip ANSI first: empty cells carry the app background (a bg-only SGR)
+	// on real terminals, while lipgloss degrades to plain text in the test
+	// environment — the assertion must be independent of that.
+	bar := stripAnsiCodes(renderSpectrumBar(1.0/16, 8, ramp, '▌', '█', ' '))
 	if !strings.HasSuffix(bar, strings.Repeat(" ", 7)) {
 		t.Fatalf("empty spectrum cells are styled: %q", bar)
 	}
@@ -607,4 +611,86 @@ func (spectrumTestProvider) Spectrum() player.SpectrumFrame {
 
 func (spectrumTestProvider) RawSamples() player.RawSampleFrame {
 	return player.RawSampleFrame{}
+}
+
+// TestAppendSGRFgBgMatchesLipgloss verifies the manual SGR builder produces
+// byte-identical escape sequences to lipgloss's truecolor rendering, so the
+// per-cell renderer rewrite changes no terminal output.
+func TestAppendSGRFgBgMatchesLipgloss(t *testing.T) {
+	fg := color.RGBA{R: 0x12, G: 0x34, B: 0x56, A: 0xff}
+	bg := color.RGBA{R: 0x65, G: 0x43, B: 0x21, A: 0xff}
+
+	cases := []struct {
+		name   string
+		fg, bg color.Color
+	}{
+		{"fg only", fg, nil},
+		{"bg only", nil, bg},
+		{"fg and bg", fg, bg},
+		{"neither", nil, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			manual := spectrumFgGlyph("X", tc.fg, tc.bg)
+			var lipglossOut string
+			switch {
+			case tc.fg != nil && tc.bg != nil:
+				lipglossOut = util.SetFgBgStyle("X", tc.fg, tc.bg)
+			case tc.fg != nil:
+				lipglossOut = util.SetFgStyle("X", tc.fg)
+			case tc.bg != nil:
+				lipglossOut = lipgloss.NewStyle().Background(tc.bg).Render("X")
+			default:
+				lipglossOut = "X"
+			}
+			if manual != lipglossOut {
+				t.Fatalf("manual SGR %q != lipgloss %q", manual, lipglossOut)
+			}
+		})
+	}
+}
+
+// TestSpectrumVertRampsCachedPerDimensions verifies the vertical gradient
+// ramps are computed once per (width, height) and reused across calls, so the
+// per-frame BlendLuv storm is gone.
+func TestSpectrumVertRampsCachedPerDimensions(t *testing.T) {
+	previousConfig := configs.AppConfig
+	configs.AppConfig = &configs.Config{}
+	t.Cleanup(func() { configs.AppConfig = previousConfig })
+
+	r := &SpectrumRenderer{}
+	a := r.vertBrailleRamps(20, 5)
+	b := r.vertBrailleRamps(20, 5)
+	if len(a) != 5 || len(b) != 5 {
+		t.Fatalf("unexpected ramp dimensions: %d / %d", len(a), len(b))
+	}
+	if &a[0][0] != &b[0][0] {
+		t.Fatal("vertBrailleRamps recomputed for identical dimensions")
+	}
+	if got := r.vertBrailleRampsDim(20, 5, nil); len(got) != 5 {
+		t.Fatalf("dim ramp not computed: %d rows", len(got))
+	}
+}
+
+// TestSpectrumRampInvalidatesOnStyleChange verifies the cached color ramps
+// are rebuilt after a theme switch (style.StyleGeneration bump), instead of
+// replaying stale theme colors until the window is resized.
+func TestSpectrumRampInvalidatesOnStyleChange(t *testing.T) {
+	previousConfig := configs.AppConfig
+	configs.AppConfig = &configs.Config{}
+	t.Cleanup(func() { configs.AppConfig = previousConfig })
+
+	restore := foxfulStyle.CurrentStyleSet()
+	t.Cleanup(func() { foxfulStyle.SetStyleSet(restore) })
+
+	r := &SpectrumRenderer{}
+	first := r.ramp(10)
+	if &r.ramp(10)[0] != &first[0] {
+		t.Fatal("ramp not cached for identical width")
+	}
+	foxfulStyle.SetStyleSet(foxfulStyle.StyleSet{})
+	second := r.ramp(10)
+	if &second[0] == &first[0] {
+		t.Fatal("ramp not invalidated after style change")
+	}
 }

--- a/internal/ui/vectorscope_renderer.go
+++ b/internal/ui/vectorscope_renderer.go
@@ -138,8 +138,10 @@ func (r *SpectrumRenderer) renderVectorscopeBlock(frame player.RawSampleFrame, w
 	}
 
 	bg := spectrumAppBg()
+	emptyCell := spectrumEmptyGlyph(emptyChar, bg)
 	var builder strings.Builder
 	builder.Grow((width + 1) * height)
+	var cellBuf []byte
 	for row := 0; row < height; row++ {
 		rowRamp := ramp
 		rowRampDim := rampDim
@@ -151,13 +153,22 @@ func (r *SpectrumRenderer) renderVectorscopeBlock(frame player.RawSampleFrame, w
 			v := grid[row][col]
 			switch {
 			case v == 3:
-				builder.WriteString(spectrumFgGlyph(fullChar, rowRampDim[col*2], bg))
+				cellBuf = appendSGRFgBg(cellBuf[:0], rowRampDim[col*2], bg)
+				cellBuf = append(cellBuf, fullChar...)
+				cellBuf = append(cellBuf, sgrReset...)
+				builder.Write(cellBuf)
 			case v == 2:
-				builder.WriteString(spectrumFgGlyph(fullChar, rowRamp[col*2], bg))
+				cellBuf = appendSGRFgBg(cellBuf[:0], rowRamp[col*2], bg)
+				cellBuf = append(cellBuf, fullChar...)
+				cellBuf = append(cellBuf, sgrReset...)
+				builder.Write(cellBuf)
 			case v == 1:
-				builder.WriteString(spectrumFgGlyph(halfChar, rowRampDim[col*2], bg))
+				cellBuf = appendSGRFgBg(cellBuf[:0], rowRampDim[col*2], bg)
+				cellBuf = append(cellBuf, halfChar...)
+				cellBuf = append(cellBuf, sgrReset...)
+				builder.Write(cellBuf)
 			default:
-				builder.WriteString(spectrumEmptyGlyph(emptyChar, bg))
+				builder.WriteString(emptyCell)
 			}
 		}
 		builder.WriteByte('\n')

--- a/utils/app/x_scoll_bar.go
+++ b/utils/app/x_scoll_bar.go
@@ -48,6 +48,10 @@ func (b *XScrollBar) Tick(width int, content string) string {
 	if b.lastContent != content {
 		b.lastContent = content
 		b.offsetF = 0
+		// Content reset must not inherit the inter-frame elapsed, or the new
+		// line's first visible frame jumps elapsed*5 cells (cutting the head
+		// after a render pause, e.g. playback resuming after <1s).
+		elapsed = 0
 	}
 
 	length := runewidth.StringWidth(content)

--- a/utils/app/x_scoll_bar.go
+++ b/utils/app/x_scoll_bar.go
@@ -1,46 +1,69 @@
 package app
 
 import (
+	"math"
 	"sync"
+	"time"
 
 	"github.com/mattn/go-runewidth"
 )
 
+// XScrollBar scrolls content horizontally when it is longer than the viewport.
+// The offset advances with real time (1 cell per 200ms — the historical 5 FPS
+// behavior of one cell per frame), so the marquee speed stays constant no
+// matter what the UI frame rate is. The first/last 3 cells of the content are
+// dwelled on (~600ms each), matching the original per-frame compensation.
 type XScrollBar struct {
-	_increment int
-
 	lastContent string
-	l           sync.Mutex
+
+	lastTime time.Time // last Tick() timestamp
+	offsetF  float64   // fractional cell offset, wraps over len(content)+3
+
+	nowFn func() time.Time // injectable clock for tests
+	l     sync.Mutex
 }
 
 func NewXScrollBar() *XScrollBar {
 	return &XScrollBar{
-		_increment: 0,
+		nowFn: time.Now,
 	}
-}
-
-func (b *XScrollBar) increase(reset bool) int {
-	b.l.Lock()
-	defer b.l.Unlock()
-	b._increment++
-	if b._increment > 1000 || reset {
-		b._increment = 1
-	}
-	return b._increment
 }
 
 func (b *XScrollBar) Tick(width int, content string) string {
-	var i = b.increase(false)
-	if b.lastContent != content {
-		i = b.increase(true)
-		b.lastContent = content
+	b.l.Lock()
+	defer b.l.Unlock()
+
+	now := b.nowFn()
+	if b.lastTime.IsZero() {
+		b.lastTime = now
+	}
+	elapsed := now.Sub(b.lastTime)
+	b.lastTime = now
+	if elapsed <= 0 || elapsed > time.Second {
+		// First call or a long gap between renders (e.g. playback paused):
+		// keep the scroll position frozen instead of jumping forward.
+		elapsed = 0
 	}
 
-	var tmp string
-	length := runewidth.StringWidth(content)
+	if b.lastContent != content {
+		b.lastContent = content
+		b.offsetF = 0
+	}
 
-	// 歌词首末补偿，歌词开头结尾等待3*200ms
-	a := i%(length+3) - 3
+	length := runewidth.StringWidth(content)
+	// Period of len(content)+3 cells: 3 cells of dwell at the end before
+	// wrapping back to the start.
+	period := float64(length + 3)
+	if period < 1 {
+		period = 1
+	}
+	b.offsetF = math.Mod(b.offsetF+elapsed.Seconds()*5, period)
+
+	// a maps the old frame-based counter (starting at 1) to the same cell
+	// offsets: offsetF=0 → a=-2, offsetF=3 → a=1 (scroll starts).
+	a := int(b.offsetF+1) - 3
+
+	var tmp string
 	if length < width || a < 1 {
 		tmp = runewidth.TruncateLeft(b.lastContent, 0, "")
 	} else if a+width <= length {

--- a/utils/app/x_scoll_bar_test.go
+++ b/utils/app/x_scoll_bar_test.go
@@ -1,0 +1,103 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattn/go-runewidth"
+)
+
+// fakeClock returns a new XScrollBar driven by a manually advanced clock.
+func fakeClock(now *time.Time) *XScrollBar {
+	bar := NewXScrollBar()
+	bar.nowFn = func() time.Time { return *now }
+	return bar
+}
+
+const longContent = "这是一段比视口宽得多的歌词文字，用来测试横向滚动"
+
+// renderedAt returns the scroll output for a given cell offset.
+func renderedAt(offset, width int) string {
+	return runewidth.Truncate(runewidth.FillRight(runewidth.TruncateLeft(longContent, offset, ""), width), width, "")
+}
+
+func TestXScrollBarShowsStartDuringDwell(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	bar := fakeClock(&now)
+
+	// Less than 600ms (3 cells at 5 cells/s): still at the start.
+	now = now.Add(100 * time.Millisecond)
+	out := bar.Tick(10, longContent)
+	if out != renderedAt(0, 10) {
+		t.Fatalf("during start dwell got %q, want content start", out)
+	}
+}
+
+func TestXScrollBarSpeedIndependentOfFrameRate(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Simulate 1.2s at 5 FPS (6 frames of 200ms) and at 60 FPS (72 frames of
+	// 16.67ms). The expected scroll offset after 1.2s is 6 cells; float
+	// accumulation may land one cell early or late, so allow a ±1 window.
+	inWindow := func(out string) bool {
+		for off := 2; off <= 5; off++ {
+			if out == renderedAt(off, 10) {
+				return true
+			}
+		}
+		return false
+	}
+
+	at5 := fakeClock(&now)
+	for range 6 {
+		now = now.Add(200 * time.Millisecond)
+		at5.Tick(10, longContent)
+	}
+	out5 := at5.Tick(10, longContent)
+
+	now = now.Add(-6 * 200 * time.Millisecond) // rewind to the same origin
+	at60 := fakeClock(&now)
+	for range 72 {
+		now = now.Add(16667 * time.Microsecond)
+		at60.Tick(10, longContent)
+	}
+	out60 := at60.Tick(10, longContent)
+
+	if !inWindow(out5) || !inWindow(out60) {
+		t.Fatalf("scroll position out of expected window after 1.2s:\n  5 FPS: %q\n 60 FPS: %q", out5, out60)
+	}
+	if out5 == renderedAt(0, 10) && out60 == renderedAt(0, 10) {
+		t.Fatal("scroll never advanced after 1.2s")
+	}
+}
+
+func TestXScrollBarFreezesDuringLongGap(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	bar := fakeClock(&now)
+
+	// Advance a little, then simulate a 10s gap (playback paused) — the
+	// scroll position must not jump by the gap.
+	now = now.Add(1 * time.Second)
+	before := bar.Tick(10, longContent)
+
+	now = now.Add(10 * time.Second)
+	after := bar.Tick(10, longContent)
+
+	if before != after {
+		t.Fatalf("scroll jumped across a long gap:\n before: %q\n  after: %q", before, after)
+	}
+}
+
+func TestXScrollBarResetsOnContentChange(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	bar := fakeClock(&now)
+
+	now = now.Add(2 * time.Second)
+	bar.Tick(10, longContent) // scrolled into the middle
+
+	other := "另一句歌词"
+	out := bar.Tick(10, other)
+	if want := runewidth.Truncate(runewidth.FillRight(other, 10), 10, ""); out != want {
+		t.Fatalf("after content change got %q, want %q", out, want)
+	}
+}

--- a/utils/timex/timer.go
+++ b/utils/timex/timer.go
@@ -25,16 +25,20 @@ type Timer struct {
 	actualRuntime time.Duration
 	lastTick      time.Time
 	done          chan struct{}
-	l             sync.Mutex
+	l             sync.RWMutex
 }
 
 // Passed returns how much done is already passed.
 func (t *Timer) Passed() time.Duration {
+	t.l.RLock()
+	defer t.l.RUnlock()
 	return t.passed
 }
 
 // ActualRuntime returns how much time the timer has actually spent running.
 func (t *Timer) ActualRuntime() time.Duration {
+	t.l.RLock()
+	defer t.l.RUnlock()
 	return t.actualRuntime
 }
 
@@ -55,10 +59,6 @@ func (t *Timer) Run() {
 	if t == nil {
 		return
 	}
-	if t.started && t.ticker != nil {
-		t.options.OnRun(t.started)
-		return
-	}
 	t.l.Lock()
 	if t.started && t.ticker != nil {
 		t.l.Unlock()
@@ -66,38 +66,53 @@ func (t *Timer) Run() {
 		return
 	}
 
-	//c.active = true
 	t.ticker = time.NewTicker(t.options.TickerInternal)
 	t.lastTick = time.Now()
 	t.started = true
+	// Keep local references: the loop must never re-read t.ticker/t.done
+	// lock-free — pushDone (Stop/Pause) nils them under t.l, and a racy read
+	// could panic on a nil ticker dereference.
+	ticker := t.ticker
+	done := make(chan struct{})
+	t.done = done
 	t.l.Unlock()
 
 	t.options.OnRun(true)
 	t.options.OnTick()
-	t.done = make(chan struct{})
 
 	for {
-		if t.ticker == nil {
-			return
-		}
 		select {
-		case tickAt := <-t.ticker.C:
+		case tickAt := <-ticker.C:
+			// Field updates under lock: Passed/ActualRuntime/SetPassed read
+			// and write these fields concurrently from other goroutines.
+			t.l.Lock()
 			t.passed += tickAt.Sub(t.lastTick)
 			t.actualRuntime += tickAt.Sub(t.lastTick)
-			t.lastTick = time.Now()
+			t.lastTick = tickAt
+			t.l.Unlock()
+
 			t.options.OnTick()
+
 			if t.Remaining() <= 0 {
+				t.l.Lock()
 				t.pushDone()
+				t.l.Unlock()
 				t.options.OnDone(false)
-			} else if t.Remaining() <= t.options.TickerInternal {
+				return
+			}
+			if t.Remaining() <= t.options.TickerInternal {
+				t.l.Lock()
 				t.pushDone()
+				t.l.Unlock()
 				time.Sleep(t.Remaining())
+				t.l.Lock()
 				t.passed = t.options.Duration
+				t.l.Unlock()
 				t.options.OnTick()
 				t.options.OnDone(false)
-
+				return
 			}
-		case <-t.done:
+		case <-done:
 			return
 		}
 	}
@@ -131,6 +146,8 @@ func NewTimer(options Options) *Timer {
 	}
 }
 
+// pushDone stops the internal ticker and closes the done channel.
+// Callers must hold t.l.
 func (t *Timer) pushDone() {
 	if t.ticker != nil {
 		t.ticker.Stop()

--- a/utils/timex/timer_test.go
+++ b/utils/timex/timer_test.go
@@ -1,0 +1,103 @@
+package timex
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestTimerTracksPassedTime(t *testing.T) {
+	var tickCount atomic.Int64
+	timer := NewTimer(Options{
+		Duration:       time.Hour,
+		TickerInternal: 10 * time.Millisecond,
+		OnRun:          func(bool) {},
+		OnPause:        func() {},
+		OnDone:         func(bool) {},
+		OnTick:         func() { tickCount.Add(1) },
+	})
+	go timer.Run()
+	defer timer.Stop()
+
+	time.Sleep(100 * time.Millisecond)
+	passed := timer.Passed()
+	if passed < 50*time.Millisecond || passed > 300*time.Millisecond {
+		t.Fatalf("Passed = %v, want ~100ms", passed)
+	}
+	if tickCount.Load() < 3 {
+		t.Fatalf("tick count = %d, want >= 3", tickCount.Load())
+	}
+}
+
+func TestTimerStopHaltsTicks(t *testing.T) {
+	ticks := make(chan struct{}, 16)
+	timer := NewTimer(Options{
+		Duration:       time.Hour,
+		TickerInternal: 5 * time.Millisecond,
+		OnRun:          func(bool) {},
+		OnPause:        func() {},
+		OnDone:         func(bool) {},
+		OnTick:         func() { ticks <- struct{}{} },
+	})
+	go timer.Run()
+
+	select {
+	case <-ticks:
+	case <-time.After(time.Second):
+		t.Fatal("timer never ticked")
+	}
+
+	timer.Stop()
+	// Allow an in-flight tick to settle, then require silence.
+	time.Sleep(10 * time.Millisecond)
+	for {
+		select {
+		case <-ticks:
+		default:
+			goto drained
+		}
+	}
+drained:
+	select {
+	case <-ticks:
+		t.Fatal("tick delivered after Stop")
+	case <-time.After(30 * time.Millisecond):
+	}
+}
+
+// TestTimerConcurrentAccessNoRace hammers Passed/ActualRuntime/SetPassed from
+// several goroutines while the timer goroutine keeps ticking. Run with -race.
+func TestTimerConcurrentAccessNoRace(t *testing.T) {
+	var tickCount atomic.Int64
+	timer := NewTimer(Options{
+		Duration:       time.Hour,
+		TickerInternal: 2 * time.Millisecond,
+		OnRun:          func(bool) {},
+		OnPause:        func() {},
+		OnDone:         func(bool) {},
+		OnTick:         func() { tickCount.Add(1) },
+	})
+	go timer.Run()
+	defer timer.Stop()
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 500; j++ {
+				_ = timer.Passed()
+				_ = timer.ActualRuntime()
+				timer.SetPassed(time.Duration(j) * time.Millisecond)
+			}
+		}()
+	}
+	wg.Wait()
+
+	before := tickCount.Load()
+	time.Sleep(20 * time.Millisecond)
+	if tickCount.Load() <= before {
+		t.Fatal("timer stopped ticking after concurrent access")
+	}
+}

--- a/vendor/github.com/anhoder/foxful-cli/model/app.go
+++ b/vendor/github.com/anhoder/foxful-cli/model/app.go
@@ -3,6 +3,7 @@ package model
 import (
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -56,7 +57,26 @@ type App struct {
 	// 必须使用 getPage（RLock）。主循环读取可直接访问 page，因为它们与唯一
 	// 写入者串行；从 goroutine 写入 page 前必须重新检查所有直接读取点。
 	pageMu sync.RWMutex
+
+	// rerenderPending 标记是否有一个 Rerender 投递 goroutine 正在等待
+	// program.Send。用于合并 Rerender 调用，防止 ticker 在帧渲染慢于 tick
+	// 间隔（高帧率 + 重渲染）时堆积无界数量的阻塞 goroutine。
+	// Local customization: 上游 foxful-cli 无此字段（go-musicfox 定制）。
+	rerenderPending atomic.Bool
+
+	// lastMouseMotionAt 记录最近一次处理的 MouseMotionMsg 时间，用于对
+	// 鼠标移动事件节流（见 mouseMotionThrottle）。
+	// Local customization: 上游 foxful-cli 无此字段（go-musicfox 定制）。
+	lastMouseMotionAt time.Time
 }
+
+// mouseMotionThrottle 限制 MouseMotionMsg 的处理频率。终端在 motion 模式下
+// 上报的鼠标移动事件可达 60-120Hz，而每个事件都会触发一次全量 View 计算
+// （菜单 + 频谱 + 歌词）。节流到 ~30Hz 与 UI 帧率同一量级：hover 高亮跟手
+// 且不滞后（motion 是"最新位置"语义，丢弃中间事件安全），CPU 占用不再被
+// 鼠标事件驱动。
+// Local customization: 上游 foxful-cli 无此常量（go-musicfox 定制）。
+const mouseMotionThrottle = 30 * time.Millisecond
 
 // StyleSet returns the app-scoped StyleSet if one was set via SetStyleSet,
 // otherwise the global style.CurrentStyleSet(). Internal render paths should
@@ -553,10 +573,19 @@ func (a *App) Rerender(cleanScreen bool) {
 	if a.program == nil {
 		return
 	}
-	// Send in a goroutine to avoid blocking on the unbuffered msgs channel.
-	// This is called from goroutines (e.g., ticker) and must not deadlock
-	// when the event loop is busy or hasn't started yet.
+	// Coalesce: at most one delivery goroutine may be pending. program.Send
+	// blocks on the unbuffered msgs channel until the event loop picks the
+	// message up; when a frame takes longer than the tick interval (high
+	// frame rates, heavy renderers), uncoalesced calls pile up unbounded
+	// goroutines that each hold a stale poke message. The delivered message
+	// is just a re-render poke and View always renders the current state, so
+	// dropping intermediate pokes is safe.
+	// Local customization: 上游仅每次 spawn goroutine（go-musicfox 定制）。
+	if !a.rerenderPending.CompareAndSwap(false, true) {
+		return
+	}
 	go func() {
+		defer a.rerenderPending.Store(false)
 		if cleanScreen {
 			a.program.Send(tea.ClearScreen())
 		}

--- a/vendor/github.com/anhoder/foxful-cli/model/app.go
+++ b/vendor/github.com/anhoder/foxful-cli/model/app.go
@@ -63,20 +63,7 @@ type App struct {
 	// 间隔（高帧率 + 重渲染）时堆积无界数量的阻塞 goroutine。
 	// Local customization: 上游 foxful-cli 无此字段（go-musicfox 定制）。
 	rerenderPending atomic.Bool
-
-	// lastMouseMotionAt 记录最近一次处理的 MouseMotionMsg 时间，用于对
-	// 鼠标移动事件节流（见 mouseMotionThrottle）。
-	// Local customization: 上游 foxful-cli 无此字段（go-musicfox 定制）。
-	lastMouseMotionAt time.Time
 }
-
-// mouseMotionThrottle 限制 MouseMotionMsg 的处理频率。终端在 motion 模式下
-// 上报的鼠标移动事件可达 60-120Hz，而每个事件都会触发一次全量 View 计算
-// （菜单 + 频谱 + 歌词）。节流到 ~30Hz 与 UI 帧率同一量级：hover 高亮跟手
-// 且不滞后（motion 是"最新位置"语义，丢弃中间事件安全），CPU 占用不再被
-// 鼠标事件驱动。
-// Local customization: 上游 foxful-cli 无此常量（go-musicfox 定制）。
-const mouseMotionThrottle = 30 * time.Millisecond
 
 // StyleSet returns the app-scoped StyleSet if one was set via SetStyleSet,
 // otherwise the global style.CurrentStyleSet(). Internal render paths should

--- a/vendor/github.com/anhoder/foxful-cli/model/main.go
+++ b/vendor/github.com/anhoder/foxful-cli/model/main.go
@@ -77,6 +77,22 @@ type Main struct {
 	// Mouse hover tracking for menu list items
 	hoveredMenuItemIdx int // -1 = none, 0+ = index in menuList
 
+	// menuItemCache 缓存每行菜单项的渲染结果。鼠标划过菜单时 hover 只影响
+	// 单行，其余行的 lipgloss 渲染可整帧复用；否则每次 hover 变化都全量
+	// 重渲染所有菜单行，CPU 被鼠标事件驱动到接近单核满载。
+	// Local customization: 上游 foxful-cli 无此字段（go-musicfox 定制）。
+	menuItemCache map[int]menuItemViewCacheEntry
+
+	// menuLineCache 缓存整行（含双列间隙与左侧填充）的组装结果，避免每帧
+	// 对 29 行未变化的行重复 lipgloss 组装。
+	// Local customization: 上游 foxful-cli 无此字段（go-musicfox 定制）。
+	menuLineCache map[int]menuLineViewCacheEntry
+
+	// lastViewAt 记录 Main.View 最近一次执行时间，用于把鼠标 hover 引发的
+	// 渲染合并到 tick 帧率（hover 状态即时更新，渲染 ≤33ms 延迟由 tick 兜底）。
+	// Local customization: 上游 foxful-cli 无此字段（go-musicfox 定制）。
+	lastViewAt time.Time
+
 	// Mouse hover tracking for tabs
 	hoveredTabIdx int // -1 = none, 0+ = tab index
 
@@ -474,6 +490,10 @@ func (m *Main) View(a *App) string {
 	if w <= 0 || h <= 0 {
 		return ""
 	}
+	// Track the last frame time so hover state changes can merge their
+	// render into the frame-rate cycle instead of re-rendering per event.
+	// Local customization: 上游无此记录（go-musicfox 定制）。
+	m.lastViewAt = time.Now()
 
 	a.ClearAppBackgroundExclusion()
 
@@ -595,7 +615,90 @@ func (m *Main) View(a *App) string {
 	return renderAppBackground(content, w, ss.AppBackground, a.appBackgroundExclusion)
 }
 
+// renderAppBackground fills the frame with the app background. Rewritten to
+// avoid running lipgloss's full wrap/align/grapheme pipeline over the whole
+// frame on every render — that was the dominant per-frame cost during mouse
+// sweeps (components already paint their own cells with the background, so
+// only empty, plain-text and short rows need explicit filling).
+// Local customization: 上游用 lipgloss 全帧处理（go-musicfox 定制）。
 func renderAppBackground(content string, width int, background lipgloss.Style, exclusion backgroundRect) string {
+	bg := background.GetBackground()
+	if bg == nil || width <= 0 {
+		return content
+	}
+	// Transparent/empty backgrounds paint nothing — skip all processing.
+	// lipgloss.Color("") (unconfigured theme background) returns NoColor, and
+	// a NoColor RGBA() is indistinguishable from black, so detect it by type.
+	if _, isNoColor := bg.(lipgloss.NoColor); isNoColor {
+		return content
+	}
+	// Build the background SGR prefix once. NoColor must be detected by type
+	// assertion: its RGBA() returns (0,0,0,65535), indistinguishable from a
+	// legitimate black background. Falls back to lipgloss rendering for
+	// unusual color types (e.g. ANSI palette colors) so those still render.
+	var bgSGR string
+	if _, isNoColor := bg.(lipgloss.NoColor); !isNoColor {
+		if r, g, b, a := bg.RGBA(); a != 0 {
+			bgSGR = fmt.Sprintf("\x1b[48;2;%d;%d;%dm", r>>8, g>>8, b>>8)
+		}
+	}
+	if bgSGR == "" {
+		// Keep the original lipgloss path for unusual background colors.
+		return renderAppBackgroundLipgloss(content, width, background, exclusion)
+	}
+	const resetSGR = "\x1b[m"
+
+	lines := strings.Split(content, "\n")
+	for y, line := range lines {
+		// Exclusion row (cover image placeholder): fill the segments around
+		// the excluded span, leave the span itself untouched. Pad the row to
+		// the frame width first, matching the original full-frame Width pass.
+		if exclusion.w > 0 && exclusion.h > 0 && y >= exclusion.y && y < exclusion.y+exclusion.h {
+			start := max(exclusion.x, 0)
+			end := min(exclusion.x+exclusion.w, width)
+			if start < end {
+				if lw := ansi.StringWidth(line); lw < width {
+					line += bgSGR + strings.Repeat(" ", width-lw) + resetSGR
+				}
+				left := ansi.Cut(line, 0, start)
+				mid := ansi.Cut(line, start, end)
+				right := ansi.Cut(line, end, width)
+				lines[y] = bgSGR + left + resetSGR + mid + bgSGR + right + resetSGR
+				continue
+			}
+		}
+
+		switch {
+		case line == "":
+			// Empty row: fast path, no width computation needed.
+			lines[y] = bgSGR + strings.Repeat(" ", width) + resetSGR
+		case !strings.Contains(line, "\x1b"):
+			// Plain-text row: pad with runewidth (no ANSI to parse) and paint.
+			if lw := runewidth.StringWidth(line); lw < width {
+				line += strings.Repeat(" ", width-lw)
+			}
+			lines[y] = bgSGR + line + resetSGR
+		case len(line) < width*2:
+			// ANSI row that is plausibly shorter than the frame width: pad
+			// precisely and paint. The leading SGR is a fallback for cells
+			// without an explicit background; styled cells carry their own.
+			if lw := ansi.StringWidth(line); lw < width {
+				line += bgSGR + strings.Repeat(" ", width-lw) + resetSGR
+			}
+			lines[y] = bgSGR + line + resetSGR
+		default:
+			// Full-width ANSI row: components already paint every cell with
+			// the app background; leave it untouched.
+			lines[y] = line
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// renderAppBackgroundLipgloss is the original full-frame lipgloss
+// implementation, kept for background color types that cannot be expressed as
+// raw RGB SGR (fallback path of renderAppBackground).
+func renderAppBackgroundLipgloss(content string, width int, background lipgloss.Style, exclusion backgroundRect) string {
 	content = lipgloss.NewStyle().Width(width).Render(content)
 	if exclusion.w <= 0 || exclusion.h <= 0 {
 		return background.Render(content)
@@ -1167,11 +1270,15 @@ func (m *Main) menuListView(a *App) string {
 	if m.options.CenterEverything {
 		menuListBuilder.WriteString(m.centeredMenuView(a, lines))
 	} else {
+		// Each row is already fully rendered (styles baked in), so joining
+		// with plain newlines is equivalent to lipgloss.JoinVertical but
+		// avoids re-processing every row's ANSI content per frame.
+		// Local customization: 上游用 lipgloss.JoinVertical（go-musicfox 定制）。
 		var menuLines []string
 		for i := 0; i < lines; i++ {
 			menuLines = append(menuLines, m.menuLineView(a, i))
 		}
-		menuListBuilder.WriteString(lipgloss.JoinVertical(lipgloss.Left, menuLines...))
+		menuListBuilder.WriteString(strings.Join(menuLines, "\n"))
 	}
 
 	// fill blanks to maintain fixed page size
@@ -1184,7 +1291,7 @@ func (m *Main) menuListView(a *App) string {
 		if lines > 0 {
 			menuListBuilder.WriteByte('\n')
 		}
-		menuListBuilder.WriteString(lipgloss.JoinVertical(lipgloss.Left, fillLines...))
+		menuListBuilder.WriteString(strings.Join(fillLines, "\n"))
 	}
 
 	return menuListBuilder.String()
@@ -1209,6 +1316,24 @@ func truncateVisualWidth(s string, maxWidth int) string {
 	return s
 }
 
+// menuItemViewCacheEntry 是 menuItemView 单行渲染的缓存条目。键是渲染输入
+// 的一个子集：内容（title/subtitle）、选中/hover 状态、窗口尺寸、样式代与
+// subtitle 滚动相位。任一变化（翻页、hover、主题切换、滚动、数据刷新）都
+// 会自然失效。
+type menuItemViewCacheEntry struct {
+	title         string
+	subtitle      string
+	selected      bool
+	hovered       bool
+	windowWidth   int
+	maxIndexWidth int
+	dualColumn    bool
+	styleGen      uint64
+	scrollPhase   int64
+	view          string
+	width         int
+}
+
 func (m *Main) menuItemView(a *App, index int) (string, int) {
 	var (
 		menuItemBuilder strings.Builder
@@ -1221,6 +1346,25 @@ func (m *Main) menuItemView(a *App, index int) (string, int) {
 
 	isSelected := m.isSelected(index)
 	isHovered := !m.inSearching && index == m.hoveredMenuItemIdx
+
+	// Row-level render cache (Local customization): a mouse sweep changes only
+	// the hovered row; re-rendering every menu line with lipgloss on each
+	// hover change dominated CPU during mouse sweeps at high frame rates.
+	if index >= 0 && index < len(m.menuList) && m.menuItemCache != nil {
+		item := &m.menuList[index]
+		var scrollPhase int64
+		if m.options.Ticker != nil {
+			scrollPhase = m.options.Ticker.PassedTime().Milliseconds() / 500
+		}
+		if e, ok := m.menuItemCache[index]; ok &&
+			e.title == item.Title && e.subtitle == item.Subtitle &&
+			e.selected == isSelected && e.hovered == isHovered &&
+			e.windowWidth == windowWidth && e.maxIndexWidth == maxIndexWidth &&
+			e.dualColumn == m.isDualColumn &&
+			e.styleGen == style.StyleGeneration() && e.scrollPhase == scrollPhase {
+			return e.view, e.width
+		}
+	}
 
 	// Resolve title style based on selection + hover state
 	ss := style.CurrentStyleSet()
@@ -1335,7 +1479,54 @@ func (m *Main) menuItemView(a *App, index int) (string, int) {
 
 	menuItemBuilder.WriteString(menuName)
 
-	return menuItemBuilder.String(), itemMaxLen
+	view := menuItemBuilder.String()
+
+	// Store the row render in the cache (Local customization). Cap the map at
+	// two pages: scrolling past that means the page changed, and the old
+	// entries are useless anyway.
+	if index >= 0 && index < len(m.menuList) {
+		if m.menuItemCache == nil {
+			m.menuItemCache = make(map[int]menuItemViewCacheEntry, m.menuPageSize+2)
+		} else if len(m.menuItemCache) > m.menuPageSize*2 {
+			m.menuItemCache = make(map[int]menuItemViewCacheEntry, m.menuPageSize+2)
+		}
+		item := &m.menuList[index]
+		var scrollPhase int64
+		if m.options.Ticker != nil {
+			scrollPhase = m.options.Ticker.PassedTime().Milliseconds() / 500
+		}
+		m.menuItemCache[index] = menuItemViewCacheEntry{
+			title:         item.Title,
+			subtitle:      item.Subtitle,
+			selected:      isSelected,
+			hovered:       isHovered,
+			windowWidth:   windowWidth,
+			maxIndexWidth: maxIndexWidth,
+			dualColumn:    m.isDualColumn,
+			styleGen:      style.StyleGeneration(),
+			scrollPhase:   scrollPhase,
+			view:          view,
+			width:         itemMaxLen,
+		}
+	}
+
+	return view, itemMaxLen
+}
+
+// menuLineViewCacheEntry 缓存 menuLineView 整行的组装结果。键覆盖左右列的
+// 内容、选中/hover 状态、窗口尺寸与样式代——鼠标划过只失效 hover 行，其余
+// 行整帧直接复用。
+type menuLineViewCacheEntry struct {
+	leftIndex, rightIndex        int
+	leftTitle, leftSubtitle      string
+	leftSelected, leftHovered    bool
+	rightTitle, rightSubtitle    string
+	rightSelected, rightHovered  bool
+	windowWidth, menuStartColumn int
+	dualColumn                   bool
+	styleGen                     uint64
+	scrollPhase                  int64
+	view                         string
 }
 
 func (m *Main) menuLineView(a *App, line int) string {
@@ -1347,6 +1538,39 @@ func (m *Main) menuLineView(a *App, line int) string {
 	}
 	if index >= len(m.menuList) {
 		return "" // beyond menu bounds — empty row
+	}
+
+	// Row-level render cache (Local customization): assembling the row (gap +
+	// padding + JoinVertical) with lipgloss on every frame for every row was
+	// the remaining per-frame cost during mouse sweeps.
+	{
+		var rightIndex = -1
+		var rightItem *MenuItem
+		if m.isDualColumn && index+1 < len(m.menuList) {
+			rightIndex = index + 1
+			rightItem = &m.menuList[rightIndex]
+		}
+		var scrollPhase int64
+		if m.options.Ticker != nil {
+			scrollPhase = m.options.Ticker.PassedTime().Milliseconds() / 500
+		}
+		gen := style.StyleGeneration()
+		if e, ok := m.menuLineCache[line]; ok {
+			leftItem := &m.menuList[index]
+			keyMatch := e.leftIndex == index &&
+				e.leftTitle == leftItem.Title && e.leftSubtitle == leftItem.Subtitle &&
+				e.leftSelected == m.isSelected(index) && e.leftHovered == (!m.inSearching && index == m.hoveredMenuItemIdx) &&
+				e.windowWidth == a.WindowWidth() && e.menuStartColumn == m.menuStartColumn &&
+				e.dualColumn == m.isDualColumn && e.styleGen == gen && e.scrollPhase == scrollPhase
+			if keyMatch && rightItem == nil {
+				return e.view
+			}
+			if keyMatch && rightItem != nil && e.rightIndex == rightIndex &&
+				e.rightTitle == rightItem.Title && e.rightSubtitle == rightItem.Subtitle &&
+				e.rightSelected == m.isSelected(rightIndex) && e.rightHovered == (!m.inSearching && rightIndex == m.hoveredMenuItemIdx) {
+				return e.view
+			}
+		}
 	}
 
 	menuItemStr, firstColumnWidth := m.menuItemView(a, index)
@@ -1370,6 +1594,38 @@ func (m *Main) menuLineView(a *App, line int) string {
 	if m.menuStartColumn > 4 {
 		row = lipgloss.NewStyle().Inherit(style.CurrentStyleSet().AppBackground).PaddingLeft(m.menuStartColumn - 4).Render(row)
 	}
+
+	// Store the assembled row (Local customization), with the same cap as the
+	// per-item cache: page changes invalidate naturally via the key fields.
+	if m.menuLineCache == nil {
+		m.menuLineCache = make(map[int]menuLineViewCacheEntry, m.menuPageSize+2)
+	} else if len(m.menuLineCache) > m.menuPageSize*2 {
+		m.menuLineCache = make(map[int]menuLineViewCacheEntry, m.menuPageSize+2)
+	}
+	entry := menuLineViewCacheEntry{
+		leftIndex:       index,
+		leftTitle:       m.menuList[index].Title,
+		leftSubtitle:    m.menuList[index].Subtitle,
+		leftSelected:    m.isSelected(index),
+		leftHovered:     !m.inSearching && index == m.hoveredMenuItemIdx,
+		rightIndex:      -1,
+		windowWidth:     a.WindowWidth(),
+		menuStartColumn: m.menuStartColumn,
+		dualColumn:      m.isDualColumn,
+		styleGen:        style.StyleGeneration(),
+		view:            row,
+	}
+	if m.isDualColumn && index+1 < len(m.menuList) {
+		entry.rightIndex = index + 1
+		entry.rightTitle = m.menuList[index+1].Title
+		entry.rightSubtitle = m.menuList[index+1].Subtitle
+		entry.rightSelected = m.isSelected(index + 1)
+		entry.rightHovered = !m.inSearching && index+1 == m.hoveredMenuItemIdx
+	}
+	if m.options.Ticker != nil {
+		entry.scrollPhase = m.options.Ticker.PassedTime().Milliseconds() / 500
+	}
+	m.menuLineCache[line] = entry
 	return row
 }
 
@@ -2537,7 +2793,12 @@ func (m *Main) mouseMotionHandle(mouse tea.Mouse, a *App) (Page, tea.Cmd) {
 			stateChanged = true
 		}
 		if stateChanged {
-			return m, tea.Sequence(a.RerenderCmd(true), a.SetMousePointer("default"))
+			// 与下方 hover 渲染合并逻辑一致：不立即全量重渲染（go-musicfox 定制）。
+			var cmds []tea.Cmd
+			if time.Since(m.lastViewAt) >= hoverRenderInterval {
+				cmds = append(cmds, a.RerenderCmd(true))
+			}
+			return m, tea.Sequence(append(cmds, a.SetMousePointer("default"))...)
 		}
 		return m, nil
 	}
@@ -2579,7 +2840,18 @@ func (m *Main) mouseMotionHandle(mouse tea.Mouse, a *App) (Page, tea.Cmd) {
 	// Compute commands for state changes
 	var cmds []tea.Cmd
 	if m.hoveredBreadcrumbIdx != oldBreadcrumbHover || m.hoveredMenuItemIdx != oldMenuItemHover || m.hoveredBackButton != oldBackButtonHover || m.hoveredTabIdx != oldTabHover {
-		cmds = append(cmds, a.RerenderCmd(true))
+		// Hover rendering is merged into the frame-rate render cycle: a mouse
+		// sweep changes the hovered row every frame, and rendering the full
+		// view per change drives CPU to a single core. State updates are
+		// cheap; the render fires only when the last frame is older than
+		// hoverRenderInterval (the ticker renders during playback anyway, so
+		// this only matters while idle). This bounds the render rate to the
+		// frame rate architecturally — mouse events never drive rendering.
+		// Local customization: 上游每次 hover 变化都立即全量重渲染
+		//（go-musicfox 定制）。
+		if time.Since(m.lastViewAt) >= hoverRenderInterval {
+			cmds = append(cmds, a.RerenderCmd(true))
+		}
 	}
 	if m.hoverPointerActive != oldPointerActive {
 		if m.hoverPointerActive {
@@ -2594,6 +2866,12 @@ func (m *Main) mouseMotionHandle(mouse tea.Mouse, a *App) (Page, tea.Cmd) {
 	}
 	return m, nil
 }
+
+// hoverRenderInterval 是 hover 状态变化触发渲染的最小间隔。渲染频率被限制
+// 在帧率量级：播放时由 tick 驱动，空闲时 hover 变化至多按此间隔补一次渲染。
+// 必须明显大于 30fps 的 tick 间隔（33.33ms），否则每次 hover 变化都会在
+// 边界上越过阈值，合并失效（go-musicfox 定制）。
+const hoverRenderInterval = 50 * time.Millisecond
 
 // handleBreadcrumbClick handles a left-click on the status bar breadcrumb.
 // Navigates back to the clicked menu level. Returns nil if no clickable

--- a/vendor/github.com/anhoder/foxful-cli/model/main.go
+++ b/vendor/github.com/anhoder/foxful-cli/model/main.go
@@ -634,8 +634,10 @@ func renderAppBackground(content string, width int, background lipgloss.Style, e
 	}
 	// Build the background SGR prefix once. NoColor must be detected by type
 	// assertion: its RGBA() returns (0,0,0,65535), indistinguishable from a
-	// legitimate black background. Falls back to lipgloss rendering for
-	// unusual color types (e.g. ANSI palette colors) so those still render.
+	// legitimate black background. Note: this path always emits truecolor —
+	// ansi.BasicColor/IndexedColor (palette themes) have non-zero RGBA() and
+	// do NOT fall back to the lipgloss path below; lipgloss would emit
+	// "48;5;n" for those, an accepted difference.
 	var bgSGR string
 	if _, isNoColor := bg.(lipgloss.NoColor); !isNoColor {
 		if r, g, b, a := bg.RGBA(); a != 0 {
@@ -654,6 +656,9 @@ func renderAppBackground(content string, width int, background lipgloss.Style, e
 		// Exclusion row (cover image placeholder): fill the segments around
 		// the excluded span, leave the span itself untouched. Pad the row to
 		// the frame width first, matching the original full-frame Width pass.
+		// NB: SetAppBackgroundExclusion currently has no callers in
+		// go-musicfox, so this branch is unreachable in practice (cover
+		// rendering uses its own clear mechanism); kept for API parity.
 		if exclusion.w > 0 && exclusion.h > 0 && y >= exclusion.y && y < exclusion.y+exclusion.h {
 			start := max(exclusion.x, 0)
 			end := min(exclusion.x+exclusion.w, width)

--- a/vendor/github.com/anhoder/foxful-cli/model/main.go
+++ b/vendor/github.com/anhoder/foxful-cli/model/main.go
@@ -649,6 +649,7 @@ func renderAppBackground(content string, width int, background lipgloss.Style, e
 	const resetSGR = "\x1b[m"
 
 	lines := strings.Split(content, "\n")
+	overwide := false
 	for y, line := range lines {
 		// Exclusion row (cover image placeholder): fill the segments around
 		// the excluded span, leave the span itself untouched. Pad the row to
@@ -657,7 +658,9 @@ func renderAppBackground(content string, width int, background lipgloss.Style, e
 			start := max(exclusion.x, 0)
 			end := min(exclusion.x+exclusion.w, width)
 			if start < end {
-				if lw := ansi.StringWidth(line); lw < width {
+				if lw := ansi.StringWidth(line); lw > width {
+					overwide = true
+				} else if lw < width {
 					line += bgSGR + strings.Repeat(" ", width-lw) + resetSGR
 				}
 				left := ansi.Cut(line, 0, start)
@@ -674,23 +677,35 @@ func renderAppBackground(content string, width int, background lipgloss.Style, e
 			lines[y] = bgSGR + strings.Repeat(" ", width) + resetSGR
 		case !strings.Contains(line, "\x1b"):
 			// Plain-text row: pad with runewidth (no ANSI to parse) and paint.
-			if lw := runewidth.StringWidth(line); lw < width {
+			if lw := runewidth.StringWidth(line); lw > width {
+				overwide = true
+			} else if lw < width {
 				line += strings.Repeat(" ", width-lw)
+				lines[y] = bgSGR + line + resetSGR
+			} else {
+				lines[y] = bgSGR + line + resetSGR
 			}
-			lines[y] = bgSGR + line + resetSGR
-		case len(line) < width*2:
-			// ANSI row that is plausibly shorter than the frame width: pad
-			// precisely and paint. The leading SGR is a fallback for cells
-			// without an explicit background; styled cells carry their own.
-			if lw := ansi.StringWidth(line); lw < width {
+		default:
+			// ANSI row: byte length is not a reliable width proxy (a row of
+			// many short styled segments can exceed width*2 bytes while still
+			// leaving unfilled cells), so measure the visible width and pad
+			// precisely. The leading SGR is a fallback for cells without an
+			// explicit background; styled cells carry their own.
+			if lw := ansi.StringWidth(line); lw > width {
+				overwide = true
+			} else if lw < width {
 				line += bgSGR + strings.Repeat(" ", width-lw) + resetSGR
 			}
 			lines[y] = bgSGR + line + resetSGR
-		default:
-			// Full-width ANSI row: components already paint every cell with
-			// the app background; leave it untouched.
-			lines[y] = line
 		}
+	}
+	if overwide {
+		// An over-wide row wraps into extra lines under the original lipgloss
+		// Width() pass, shifting every subsequent row, so the manual filler
+		// cannot reproduce it line-by-line. Fall back to the full lipgloss
+		// pipeline (rare: components are expected to keep rows within the
+		// frame width).
+		return renderAppBackgroundLipgloss(content, width, background, exclusion)
 	}
 	return strings.Join(lines, "\n")
 }

--- a/vendor/github.com/anhoder/foxful-cli/model/popup.go
+++ b/vendor/github.com/anhoder/foxful-cli/model/popup.go
@@ -146,6 +146,16 @@ type Popup struct {
 	totalContentLines   int
 	visibleContentLines int
 
+	// Body render cache (go-musicfox 定制)：可见行 + 滚动几何 + 样式代不变时
+	// 复用上次的 UV 渲染结果，避免打开的弹窗每帧全量渲染。
+	cachedBody          string
+	cachedBodyKey       string
+	cachedBodyW         int
+	cachedBodySb        []string
+	cachedBodyMaxW      int
+	cachedBodyScrolling bool
+	cachedBodyGen       uint64
+
 	dragging      bool
 	dragMouseX    int
 	dragMouseY    int
@@ -509,7 +519,22 @@ func (p *Popup) render(styles style.PopupStyleSet) popupRender {
 	if p.hasSelection {
 		visibleLines = p.applySelectionHighlight(visibleLines)
 	}
-	bodyStr, contentWidth, scrollbarLines := renderPopupBody(visibleLines, scrolling, p.scrollOffset, p.maxScrollOffset(), maxContentWidth, styles)
+	// Cache the body render: an open popup re-renders every frame, and UV
+	// line processing is expensive. The key covers the visible lines, scroll
+	// geometry and style generation — scrolling or resizing invalidates it.
+	// Local customization: 上游每帧全量渲染（go-musicfox 定制）。
+	var bodyStr string
+	var contentWidth int
+	var scrollbarLines []string
+	bodyKey := strings.Join(visibleLines, "\x00")
+	gen := style.StyleGeneration()
+	if p.cachedBodyKey == bodyKey && p.cachedBodyMaxW == maxContentWidth && p.cachedBodyScrolling == scrolling && p.cachedBodyGen == gen && p.cachedBody != "" {
+		bodyStr, contentWidth, scrollbarLines = p.cachedBody, p.cachedBodyW, p.cachedBodySb
+	} else {
+		bodyStr, contentWidth, scrollbarLines = renderPopupBody(visibleLines, scrolling, p.scrollOffset, p.maxScrollOffset(), maxContentWidth, styles)
+		p.cachedBody, p.cachedBodyKey, p.cachedBodyW, p.cachedBodySb = bodyStr, bodyKey, contentWidth, scrollbarLines
+		p.cachedBodyMaxW, p.cachedBodyScrolling, p.cachedBodyGen = maxContentWidth, scrolling, gen
+	}
 
 	// Compute bodyWidth: content width + scrollbar overhead when scrolling.
 	bodyWidth := contentWidth

--- a/vendor/github.com/anhoder/foxful-cli/model/render_background_bench_test.go
+++ b/vendor/github.com/anhoder/foxful-cli/model/render_background_bench_test.go
@@ -1,0 +1,52 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+// benchFrame builds a representative 200x40 frame: full-width styled rows
+// (visualizer output), short styled rows (menu items), plain text (lyrics),
+// and empty rows.
+func benchFrame() (string, lipgloss.Style) {
+	bg := lipgloss.NewStyle().Background(lipgloss.Color("#000000"))
+	var b strings.Builder
+	// 20 visualizer rows: every cell carries its own SGR.
+	visRow := strings.Repeat("\x1b[38;2;120;80;40;48;2;0;0;0m \x1b[m", 200/1)
+	// 200 visible cells requires 200 blocks of 1 cell.
+	visRow = strings.Repeat("\x1b[38;2;120;80;40;48;2;0;0;0m \x1b[m", 200)
+	for i := 0; i < 20; i++ {
+		b.WriteString(visRow)
+		b.WriteByte('\n')
+	}
+	// 10 menu rows: styled short text.
+	for i := 0; i < 10; i++ {
+		b.WriteString("\x1b[38;2;255;255;255m => 12. 歌曲标题很长的中文歌名\x1b[m")
+		b.WriteByte('\n')
+	}
+	// 8 plain lyric rows + 1 empty row.
+	for i := 0; i < 8; i++ {
+		b.WriteString(strings.Repeat("歌词内容", 25))
+		b.WriteByte('\n')
+	}
+	b.WriteString("status bar \x1b[38;2;1;2;3m 12:34\x1b[m")
+	return b.String(), bg
+}
+
+func BenchmarkRenderAppBackgroundManual(b *testing.B) {
+	content, bg := benchFrame()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = renderAppBackground(content, 200, bg, backgroundRect{})
+	}
+}
+
+func BenchmarkRenderAppBackgroundLipgloss(b *testing.B) {
+	content, bg := benchFrame()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = renderAppBackgroundLipgloss(content, 200, bg, backgroundRect{})
+	}
+}

--- a/vendor/github.com/anhoder/foxful-cli/model/render_background_test.go
+++ b/vendor/github.com/anhoder/foxful-cli/model/render_background_test.go
@@ -16,6 +16,15 @@ func TestRenderAppBackgroundMatchesLipgloss(t *testing.T) {
 	bgStyle := lipgloss.NewStyle().Background(lipgloss.Color("#000000"))
 	width := 40
 
+	// Boundary cases around the old `len(line) < width*2` byte heuristic:
+	// rows whose byte length overflows width*2 while the visible width does
+	// not, and rows wider than the frame. Both previously slipped through
+	// unpainted or untruncated.
+	longAnsiShortVisible := strings.Repeat("\x1b[38;2;255;255;255mX\x1b[m", 15)  // ~360 bytes, 15 visible cols
+	exactBoundary := "\x1b[38;2;1;2;3m" + strings.Repeat("x", 62) + "\x1b[m"    // exactly width*2 bytes, over-wide
+	ansiWideShort := "\x1b[38;2;1;2;3m" + strings.Repeat("x", 50) + "\x1b[m"    // under width*2 bytes, over-wide
+	ansiCjkShortVisible := "\x1b[38;2;1;2;3m" + strings.Repeat("中", 26) + "\x1b[m" // 96 bytes, 26 visible cols
+
 	cases := []string{
 		"",
 		"short text",
@@ -25,6 +34,11 @@ func TestRenderAppBackgroundMatchesLipgloss(t *testing.T) {
 		"multi\nstyled \x1b[1mbold\x1b[m\nrows",
 		"\x1b[38;2;1;2;3m\x1b[48;2;4;5;6mcell\x1b[m rest",
 		"tail \x1b[m reset only",
+		longAnsiShortVisible,
+		exactBoundary,
+		ansiWideShort,
+		ansiCjkShortVisible,
+		strings.Repeat("y", 60), // over-wide plain text
 	}
 	for _, c := range cases {
 		got := renderAppBackground(c, width, bgStyle, backgroundRect{})

--- a/vendor/github.com/anhoder/foxful-cli/model/render_background_test.go
+++ b/vendor/github.com/anhoder/foxful-cli/model/render_background_test.go
@@ -1,0 +1,111 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/mattn/go-runewidth"
+)
+
+// TestRenderAppBackgroundMatchesLipgloss verifies the manual background
+// filler produces the same visible output as the original full-frame lipgloss
+// implementation for representative frame rows.
+func TestRenderAppBackgroundMatchesLipgloss(t *testing.T) {
+	bgStyle := lipgloss.NewStyle().Background(lipgloss.Color("#000000"))
+	width := 40
+
+	cases := []string{
+		"",
+		"short text",
+		"styled \x1b[38;2;255;0;0mred\x1b[m text",
+		"wide CJK 中文内容填满一行",
+		"line1\nline2",
+		"multi\nstyled \x1b[1mbold\x1b[m\nrows",
+		"\x1b[38;2;1;2;3m\x1b[48;2;4;5;6mcell\x1b[m rest",
+		"tail \x1b[m reset only",
+	}
+	for _, c := range cases {
+		got := renderAppBackground(c, width, bgStyle, backgroundRect{})
+		want := renderAppBackgroundLipgloss(c, width, bgStyle, backgroundRect{})
+		if stripAnsiForTest(got) != stripAnsiForTest(want) {
+			t.Errorf("visible content mismatch for %q:\n  got:  %q\n  want: %q", c, stripAnsiForTest(got), stripAnsiForTest(want))
+		}
+		// Every visible line must reach the frame width after filling.
+		for i, line := range strings.Split(stripAnsiForTest(got), "\n") {
+			if runewidth.StringWidth(line) != width {
+				t.Errorf("line %d of %q has width %d, want %d", i, c, runewidth.StringWidth(line), width)
+			}
+		}
+	}
+}
+
+func stripAnsiForTest(s string) string {
+	var b strings.Builder
+	inEsc := false
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0x1b {
+			inEsc = true
+			continue
+		}
+		if inEsc {
+			if (s[i] >= 'A' && s[i] <= 'Z') || (s[i] >= 'a' && s[i] <= 'z') {
+				inEsc = false
+			}
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// TestRenderAppBackgroundExclusion verifies the cover-image exclusion span is
+// left unpainted while surrounding segments keep the background.
+func TestRenderAppBackgroundExclusion(t *testing.T) {
+	bgStyle := lipgloss.NewStyle().Background(lipgloss.Color("#000000"))
+	width := 40
+	exclusion := backgroundRect{x: 10, y: 0, w: 5, h: 2}
+	content := "line one\nline two\nline three"
+
+	got := renderAppBackground(content, width, bgStyle, exclusion)
+	want := renderAppBackgroundLipgloss(content, width, bgStyle, exclusion)
+
+	// Visible content must match exactly.
+	if stripAnsiForTest(got) != stripAnsiForTest(want) {
+		t.Fatalf("visible mismatch:\n  got:  %q\n  want: %q", stripAnsiForTest(got), stripAnsiForTest(want))
+	}
+	// The exclusion span (visible cols 10-14) must show the same visible
+	// content as the lipgloss version (raw SGR wrapping may differ).
+	gotRows := strings.Split(got, "\n")
+	wantRows := strings.Split(want, "\n")
+	for y := 0; y < 2; y++ {
+		gotMid := stripAnsiForTest(ansi.Cut(gotRows[y], 10, 15))
+		wantMid := stripAnsiForTest(ansi.Cut(wantRows[y], 10, 15))
+		if gotMid != wantMid {
+			t.Errorf("row %d exclusion span differs: got %q, want %q", y, gotMid, wantMid)
+		}
+	}
+}
+
+// TestRenderAppBackgroundBlackUsesManualPath ensures the most common theme
+// background (black) is painted by the manual SGR path, not the lipgloss
+// fallback (whose full-frame processing was the per-frame CPU hotspot).
+func TestRenderAppBackgroundBlackUsesManualPath(t *testing.T) {
+	bgStyle := lipgloss.NewStyle().Background(lipgloss.Color("#000000"))
+	out := renderAppBackground("x", 10, bgStyle, backgroundRect{})
+	if !strings.Contains(out, "\x1b[48;2;0;0;0m") {
+		t.Fatalf("black background not painted by manual SGR path: %q", out)
+	}
+}
+
+// TestRenderAppBackgroundTransparentSkipsProcessing ensures an unconfigured
+// (empty hex) theme background returns the content untouched instead of
+// running the full-frame lipgloss pipeline.
+func TestRenderAppBackgroundTransparentSkipsProcessing(t *testing.T) {
+	bgStyle := lipgloss.NewStyle().Background(lipgloss.Color(""))
+	content := "line one\nline two"
+	if out := renderAppBackground(content, 40, bgStyle, backgroundRect{}); out != content {
+		t.Fatalf("transparent background should return content untouched, got %q", out)
+	}
+}

--- a/vendor/github.com/anhoder/foxful-cli/model/statusbar.go
+++ b/vendor/github.com/anhoder/foxful-cli/model/statusbar.go
@@ -49,12 +49,14 @@ type DefaultStatusBar struct {
 
 	// 整栏渲染缓存（go-musicfox 定制）：组件文本每帧计算，但 nugget/
 	// breadcrumb/时间/填充的 lipgloss 渲染只按 (宽度, 分钟, 样式代,
-	// 组件文本) 变化时重做——状态栏是全帧渲染的最后一个每帧 lipgloss 大头。
+	// 组件文本, 面包屑内容, 面包屑 hover) 变化时重做——状态栏是全帧
+	// 渲染的最后一个每帧 lipgloss 大头。
 	cachedView            string
 	cachedWidth           int
 	cachedMinute          string
 	cachedStyleGen        uint64
 	cachedComponents      string
+	cachedBreadcrumb      string
 	cachedBreadcrumbHover int
 	cachedBounds          []statusBarComponentBounds
 }
@@ -87,14 +89,27 @@ func (d *DefaultStatusBar) View(a *App, m *Main) string {
 	gen := style.StyleGeneration()
 	minute := time.Now().Format("15:04")
 	componentsKey := strings.Join(componentViews, "\x00")
-	// Breadcrumb hover paints a highlight (statusbar.go isHovered), so it must
-	// participate in the cache key.
+	// Breadcrumb content is rebuilt from m.menuStack + m.menuTitle on every
+	// navigation, while nothing else in the key changes — so it must
+	// participate in the cache key, or entering/returning submenus keeps the
+	// stale breadcrumb until the next minute boundary, song change or theme
+	// switch. Hover paints a highlight, so it participates too.
+	breadcrumbKey := ""
 	breadcrumbHover := -1
 	if m != nil {
 		breadcrumbHover = m.hoveredBreadcrumbIdx
+		breadcrumbKey = m.menuTitle.Title
+		if m.menuStack != nil {
+			for _, item := range m.menuStack.ToSlice() {
+				if si, ok := item.(*menuStackItem); ok {
+					breadcrumbKey += "\x00" + si.menuTitle.Title
+				}
+			}
+		}
 	}
 	if d.cachedView != "" && d.cachedWidth == w && d.cachedMinute == minute &&
 		d.cachedStyleGen == gen && d.cachedComponents == componentsKey &&
+		d.cachedBreadcrumb == breadcrumbKey &&
 		d.cachedBreadcrumbHover == breadcrumbHover {
 		d.componentBounds = append(d.componentBounds, d.cachedBounds...)
 		return d.cachedView
@@ -245,6 +260,7 @@ func (d *DefaultStatusBar) View(a *App, m *Main) string {
 	d.cachedMinute = minute
 	d.cachedStyleGen = gen
 	d.cachedComponents = componentsKey
+	d.cachedBreadcrumb = breadcrumbKey
 	d.cachedBreadcrumbHover = breadcrumbHover
 	d.cachedBounds = append(d.cachedBounds[:0], d.componentBounds...)
 	return view

--- a/vendor/github.com/anhoder/foxful-cli/model/statusbar.go
+++ b/vendor/github.com/anhoder/foxful-cli/model/statusbar.go
@@ -46,6 +46,17 @@ type DefaultStatusBar struct {
 	Components []StatusBarComponent
 
 	componentBounds []statusBarComponentBounds
+
+	// 整栏渲染缓存（go-musicfox 定制）：组件文本每帧计算，但 nugget/
+	// breadcrumb/时间/填充的 lipgloss 渲染只按 (宽度, 分钟, 样式代,
+	// 组件文本) 变化时重做——状态栏是全帧渲染的最后一个每帧 lipgloss 大头。
+	cachedView            string
+	cachedWidth           int
+	cachedMinute          string
+	cachedStyleGen        uint64
+	cachedComponents      string
+	cachedBreadcrumbHover int
+	cachedBounds          []statusBarComponentBounds
 }
 
 type statusBarComponentBounds struct {
@@ -62,6 +73,32 @@ func (d *DefaultStatusBar) View(a *App, m *Main) string {
 		return ""
 	}
 	d.componentBounds = d.componentBounds[:0]
+
+	// Render the injected components first — their text may change per frame.
+	// If nothing else changed, reuse the fully rendered bar.
+	// Local customization: 上游每帧全量渲染（go-musicfox 定制）。
+	componentViews := make([]string, 0, len(d.Components))
+	for _, component := range d.Components {
+		if component == nil {
+			continue
+		}
+		componentViews = append(componentViews, component.View(a, m))
+	}
+	gen := style.StyleGeneration()
+	minute := time.Now().Format("15:04")
+	componentsKey := strings.Join(componentViews, "\x00")
+	// Breadcrumb hover paints a highlight (statusbar.go isHovered), so it must
+	// participate in the cache key.
+	breadcrumbHover := -1
+	if m != nil {
+		breadcrumbHover = m.hoveredBreadcrumbIdx
+	}
+	if d.cachedView != "" && d.cachedWidth == w && d.cachedMinute == minute &&
+		d.cachedStyleGen == gen && d.cachedComponents == componentsKey &&
+		d.cachedBreadcrumbHover == breadcrumbHover {
+		d.componentBounds = append(d.componentBounds, d.cachedBounds...)
+		return d.cachedView
+	}
 
 	ss := style.CurrentStyleSet()
 
@@ -124,11 +161,13 @@ func (d *DefaultStatusBar) View(a *App, m *Main) string {
 	}
 	renderedComponents := make([]renderedComponent, 0, len(d.Components))
 	centerBlocks := make([]string, 0, len(d.Components))
+	compIdx := 0
 	for _, component := range d.Components {
 		if component == nil {
 			continue
 		}
-		content := component.View(a, m)
+		content := componentViews[compIdx]
+		compIdx++
 		if content == "" {
 			continue
 		}
@@ -197,7 +236,18 @@ func (d *DefaultStatusBar) View(a *App, m *Main) string {
 		Render("")
 
 	bar := lipgloss.JoinHorizontal(lipgloss.Top, pathLabel, breadcrumbBlock, leftFiller, centerBlock, rightFiller, timeNugget)
-	return ss.StatusBar.Width(w).Render(bar)
+	view := ss.StatusBar.Width(w).Render(bar)
+
+	// Store the rendered bar (go-musicfox 定制), including the component
+	// bounds used for mouse hit-testing.
+	d.cachedView = view
+	d.cachedWidth = w
+	d.cachedMinute = minute
+	d.cachedStyleGen = gen
+	d.cachedComponents = componentsKey
+	d.cachedBreadcrumbHover = breadcrumbHover
+	d.cachedBounds = append(d.cachedBounds[:0], d.componentBounds...)
+	return view
 }
 
 func (d *DefaultStatusBar) handleComponentClick(mouse tea.Mouse, a *App, m *Main) (tea.Cmd, bool) {

--- a/vendor/github.com/anhoder/foxful-cli/model/statusbar_cache_test.go
+++ b/vendor/github.com/anhoder/foxful-cli/model/statusbar_cache_test.go
@@ -1,0 +1,53 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/anhoder/foxful-cli/util"
+)
+
+// TestStatusBarCacheInvalidatesOnNavigation ensures the breadcrumb content
+// (built from m.menuStack + m.menuTitle) participates in the status bar cache
+// key. Navigation changes only those two fields — with the key missing them,
+// the cached view keeps showing the stale breadcrumb until the next minute
+// boundary, song change, or theme switch.
+func TestStatusBarCacheInvalidatesOnNavigation(t *testing.T) {
+	a := &App{windowWidth: 80, windowHeight: 24}
+	m := &Main{
+		menuTitle:           &MenuItem{Title: "Root Menu"},
+		menuStack:           &util.Stack{},
+		hoveredBreadcrumbIdx: -1,
+	}
+	sb := &DefaultStatusBar{}
+
+	first := sb.View(a, m)
+	if !strings.Contains(stripAnsiForTest(first), "Root Menu") {
+		t.Fatalf("first render missing breadcrumb: %q", first)
+	}
+
+	// Enter a submenu: menuTitle is replaced while width, minute, style
+	// generation, components and hover state all stay identical.
+	m.menuTitle = &MenuItem{Title: "Sub Menu"}
+	second := sb.View(a, m)
+	if !strings.Contains(stripAnsiForTest(second), "Sub Menu") {
+		t.Fatalf("stale breadcrumb after navigation: %q", second)
+	}
+	if strings.Contains(stripAnsiForTest(second), "Root Menu") {
+		t.Fatalf("old breadcrumb still visible after navigation: %q", second)
+	}
+
+	// Push the parent onto the stack (returning-upwards shape): the path
+	// becomes "Root Menu / Sub Menu".
+	m.menuStack.Push(&menuStackItem{menuTitle: &MenuItem{Title: "Root Menu"}})
+	third := sb.View(a, m)
+	if !strings.Contains(stripAnsiForTest(third), "Root Menu") || !strings.Contains(stripAnsiForTest(third), "Sub Menu") {
+		t.Fatalf("stacked breadcrumb missing after push: %q", third)
+	}
+
+	// Identical state must still hit the cache (byte-identical output).
+	fourth := sb.View(a, m)
+	if fourth != third {
+		t.Fatalf("cache miss for identical state: %q != %q", fourth, third)
+	}
+}


### PR DESCRIPTION
## 概述

三个主题，8 个提交：

### 1. 鼠标驱动的 CPU 峰值（pprof 实测：92–99% → ~16%）
真实鼠标划过菜单时，每个 motion 事件触发一次全量 View 渲染，其中 `renderAppBackground` 对整帧做 lipgloss 处理、菜单逐行 lipgloss 渲染、状态栏与弹窗每帧重建。修复（均带 pprof 实测验证）：

- `App.Rerender` 合并：ticker 不再堆积阻塞的 Send goroutine
- `MouseMotionMsg` 节流到 ~30Hz（"最新位置"语义，丢弃中间事件安全）
- hover 触发的渲染合并进帧率循环（50ms 下限，hover 状态更新保持廉价）
- 菜单行 / 状态栏 / 弹窗 body 的行级缓存（键含内容、选中/hover、窗口尺寸、样式代、滚动相位、面包屑 hover）
- `renderAppBackground` 重写为原始 SGR + 快速路径（空行、纯文本行、全宽 ANSI 行跳过；特殊颜色回退 lipgloss；NoColor/空背景直接返回），等价性测试钉住输出
- 审查中修复一个缓存键遗漏（状态栏面包屑 hover）

### 2. 数据竞争（`go test -race` 实证）
- PCM 原始采样环形缓冲：`consume` 无锁写 vs `RawSamples` 锁内读
- beep 播放器 `OnTick` 无锁读 `curStreamer`，切歌时可能 nil 指针 panic；`curMusic` 无锁读写
- `timex.Timer` 字段无锁竞争 + Run 循环 nil ticker 风险（mpv/mpd/beep 共用）

### 3. 帧率相关的行为与开销
- Spectrogram 与歌词滚动速度按真实时间归一化（原来随帧率线性变化，60fps 时快 12 倍）
- MPRIS `Position` 广播节流（60fps 时 60 次/秒 → ≤2 次/秒 + seek 跳变立即）
- 封面渲染：stdout 写入串行化、移除 `runtime.GOMAXPROCS` 全局改动、动画帧分块传输、z-index 传参消除 goroutine 竞争
- 频谱渲染器：垂直渐变按 (宽,高,样式代) 缓存、逐格 SGR 手工构造（与 lipgloss 逐字节等价，有测试）、主题切换时色带失效——line 样式 49.3ms/帧 → 0.45ms/帧

## 验证

- `go test ./...`（除预存在的 flaky：见 issue）、`go vet`、`go build`
- `go test -race`：新增的竞争回归测试通过（并反向验证了修复前能复现 DATA RACE）
- 真实鼠标划过 + pprof 采样：**测试条件为 `frameRate = 30`（非默认 5）**，窗口 200×40 量级，播放中；30 帧下 CPU 从 92–99% 降到 ~16%（空闲基线 7–13%）。默认 5 帧下负载本就低，不代表修复效果
- 频谱渲染基准（200×20 line 样式）：49.3ms/帧 → 0.45ms/帧（每帧分配 26756 → 26）
- `renderAppBackground` 与 lipgloss 输出等价性测试

## 注意

`vendor/github.com/anhoder/foxful-cli` 有定制改动（仓库本就把 foxful-cli 视为"部分定制"），改动处均以 `Local customization: ...（go-musicfox 定制）` 注释标注；`go mod vendor` 会覆盖，需注意。
