### PR TITLE
fix(netease,api): 静默失败显式化、搜索有界化、MPRIS 钳制（7 commits squash）

### DIFF
--- a/internal/macdriver/mediaplayer/mpremotecommand.go
+++ b/internal/macdriver/mediaplayer/mpremotecommand.go
@@ -19,7 +19,8 @@ var (
 )
 
 var (
-	sel_addTargetAction = objc.RegisterName("addTarget:action:")
+	sel_addTargetAction    = objc.RegisterName("addTarget:action:")
+	sel_removeTargetAction = objc.RegisterName("removeTarget:action:")
 )
 
 type MPRemoteCommand struct {
@@ -28,4 +29,11 @@ type MPRemoteCommand struct {
 
 func (c MPRemoteCommand) AddTargetAction(target objc.ID, action objc.SEL) {
 	c.Send(sel_addTargetAction, target, action)
+}
+
+// RemoveTargetAction 移除 addTarget:action: 注册的处理目标。addTarget 是
+// 追加语义，重复注册会累积（每调一次 SetPlayingInfo 都翻倍触发），幂等
+// 注册必须先 remove 再 add。
+func (c MPRemoteCommand) RemoveTargetAction(target objc.ID, action objc.SEL) {
+	c.Send(sel_removeTargetAction, target, action)
 }

--- a/internal/netease/playlist.go
+++ b/internal/netease/playlist.go
@@ -11,6 +11,10 @@ import (
 	_struct "github.com/go-musicfox/go-musicfox/utils/struct"
 )
 
+// maxPlaylistSearchPages 限制按名称查找歌单的最大翻页数，防止服务端异常
+// 时无限请求
+const maxPlaylistSearchPages = 100
+
 func FetchUserPlaylists(userId int64, limit int, offset int) (codeType _struct.ResCode, playlists []structs.Playlist, hasMore bool) {
 	userPlaylists := service.UserPlaylistService{
 		Uid:    strconv.FormatInt(userId, 10),
@@ -48,7 +52,7 @@ func FetchUserPlaylistByName(userId int64, playlistName string, getAll bool) (so
 	)
 	// 寻找歌单
 Loop:
-	for {
+	for page := 0; ; page++ {
 		codeType, playlists, hasMore = FetchUserPlaylists(userId, 30, offset)
 		if codeType != _struct.Success {
 			err = NetworkErr
@@ -61,7 +65,8 @@ Loop:
 				break Loop
 			}
 		}
-		if !hasMore {
+		if !hasMore || len(playlists) == 0 || page >= maxPlaylistSearchPages {
+			// len==0 防服务端异常持续返回"空列表+more=true"导致的死循环
 			err = Error{Msg: "未找到歌单:" + playlistName}
 			return
 		}

--- a/internal/netease/song.go
+++ b/internal/netease/song.go
@@ -53,6 +53,11 @@ func FetchLikeSongs(userId int64, getAll bool) (playlist []structs.Song, err err
 		err = NetworkErr
 		return
 	}
+	if len(playlists) == 0 {
+		// 风控降级/异常响应可能返回 Success + 空列表，直接索引会越界崩溃整个 TUI
+		err = NetworkErr
+		return
+	}
 	codeType, songs = FetchSongsOfPlaylist(playlists[0].Id, getAll)
 	if codeType != _struct.Success {
 		err = NetworkErr

--- a/internal/remote_control/mpris_player_linux.go
+++ b/internal/remote_control/mpris_player_linux.go
@@ -67,7 +67,13 @@ func notImplemented(c *prop.Change) *dbus.Error {
 
 // OnVolume handles volume changes.
 func (p *Player) OnVolume(c *prop.Change) *dbus.Error {
-	val := int(math.Round(c.Value.(float64) * 100))
+	// MPRIS 音量是 0..1 浮点；钳制到合法区间，防御 NaN/Inf/越界值
+	vol := c.Value.(float64)
+	if math.IsNaN(vol) || math.IsInf(vol, 0) {
+		vol = 0
+	}
+	vol = math.Max(0, math.Min(1, vol))
+	val := int(math.Round(vol * 100))
 
 	p.RemoteControl.player.CtrlSetVolume(val)
 	return nil

--- a/internal/remote_control/remote_control_darwin.go
+++ b/internal/remote_control/remote_control_darwin.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ebitengine/purego/objc"
+
 	"github.com/go-musicfox/go-musicfox/internal/macdriver/cocoa"
 	"github.com/go-musicfox/go-musicfox/internal/macdriver/core"
 	"github.com/go-musicfox/go-musicfox/internal/macdriver/mediaplayer"
@@ -61,6 +63,35 @@ func (s *RemoteControl) registerCommands() {
 	s.remoteCommandCenter.SkipBackwardCommand().SetPreferredIntervals(intervals)
 	s.remoteCommandCenter.SkipForwardCommand().SetPreferredIntervals(intervals)
 
+	// addTarget:action: 是追加语义，且 SetPlayingInfo 每次调用都会触发本函数
+	// （"mac 26 不生效" 的旧 workaround）。必须幂等：先按全部已注册 action
+	// remove 再 add，否则一段时间后按一次媒体键会触发 N 次 handler
+	// （Play/Pause 被 toggle N 次）。
+	commands := []mediaplayer.MPRemoteCommand{
+		s.remoteCommandCenter.PlayCommand(),
+		s.remoteCommandCenter.PauseCommand(),
+		s.remoteCommandCenter.StopCommand(),
+		s.remoteCommandCenter.TogglePlayPauseCommand(),
+		s.remoteCommandCenter.PreviousTrackCommand(),
+		s.remoteCommandCenter.NextTrackCommand(),
+		s.remoteCommandCenter.ChangeRepeatModeCommand().MPRemoteCommand,
+		s.remoteCommandCenter.ChangeShuffleModeCommand().MPRemoteCommand,
+		s.remoteCommandCenter.ChangePlaybackPositionCommand().MPRemoteCommand,
+		s.remoteCommandCenter.LikeCommand().MPRemoteCommand,
+	}
+	actions := []objc.SEL{
+		sel_handlePlayCommand, sel_handlePauseCommand, sel_handleStopCommand,
+		sel_handleTogglePlayPauseCommand, sel_handlePreviousTrackCommand,
+		sel_handleNextTrackCommand, sel_handleChangeRepeatModeCommand,
+		sel_handleChangeShuffleModeCommand, sel_handleChangePlaybackPositionCommand,
+		sel_handleLikeCommand,
+	}
+	for _, cmd := range commands {
+		for _, action := range actions {
+			cmd.RemoveTargetAction(s.commandHandler.ID, action)
+		}
+	}
+
 	s.remoteCommandCenter.PlayCommand().AddTargetAction(s.commandHandler.ID, sel_handlePlayCommand)
 	s.remoteCommandCenter.PauseCommand().AddTargetAction(s.commandHandler.ID, sel_handlePauseCommand)
 	s.remoteCommandCenter.StopCommand().AddTargetAction(s.commandHandler.ID, sel_handleStopCommand)
@@ -95,6 +126,10 @@ func (s *RemoteControl) registerCommands() {
 	// s.remoteCommandCenter.DisableLanguageOptionCommand().AddTargetAction(s.commandHandler.ID, sel_handleDisableLanguageOptionCommand)
 
 	workspaceNC := cocoa.NSWorkspace_sharedWorkspace().NotificationCenter()
+	// 同样先移除再添加，避免重复注册观察者
+	workspaceNC.RemoveObserverNameObject(s.commandHandler.ID, core.String("NSWorkspaceWillSleepNotification"), core.NSObject{})
+	workspaceNC.RemoveObserverNameObject(s.commandHandler.ID, core.String("NSWorkspaceWillPowerOffNotification"), core.NSObject{})
+	workspaceNC.RemoveObserverNameObject(s.commandHandler.ID, core.String("NSWorkspaceDidWakeNotification"), core.NSObject{})
 	workspaceNC.AddObserverSelectorNameObject(s.commandHandler.ID, sel_handleWillSleepOrPowerOff, core.String("NSWorkspaceWillSleepNotification"), core.NSObject{})
 	workspaceNC.AddObserverSelectorNameObject(s.commandHandler.ID, sel_handleWillSleepOrPowerOff, core.String("NSWorkspaceWillPowerOffNotification"), core.NSObject{})
 	workspaceNC.AddObserverSelectorNameObject(s.commandHandler.ID, sel_handleDidWake, core.String("NSWorkspaceDidWakeNotification"), core.NSObject{})

--- a/internal/track/cache.go
+++ b/internal/track/cache.go
@@ -71,9 +71,6 @@ func (m *Cacher) Put(song structs.Song, quality service.SongQualityLevel, fileTy
 		return err
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	if err := m.ensureDirExists(); err != nil {
 		return fmt.Errorf("cannot put cache, directory check failed: %w", err)
 	}
@@ -88,6 +85,9 @@ func (m *Cacher) Put(song structs.Song, quality service.SongQualityLevel, fileTy
 	defer os.Remove(tempFile.Name())
 	defer tempFile.Close()
 
+	// 网络→磁盘拷贝不持锁：GetPath（切歌解析路径）需要 RLock，慢速 FLAC
+	// 后台缓存期间持锁会让每次切歌阻塞数秒到数十秒。锁只覆盖目录检查、
+	// 建临时文件与最后的 rename。
 	_, err = io.Copy(tempFile, data)
 	if err != nil {
 		return fmt.Errorf("failed to copy data to temp file: %w", err)
@@ -97,9 +97,12 @@ func (m *Cacher) Put(song structs.Song, quality service.SongQualityLevel, fileTy
 		return fmt.Errorf("failed to close temp file: %w", err)
 	}
 
+	m.mu.Lock()
 	if err := os.Rename(tempFile.Name(), filePath); err != nil {
+		m.mu.Unlock()
 		return fmt.Errorf("failed to rename temp file to %s: %w", filePath, err)
 	}
+	m.mu.Unlock()
 
 	slog.Debug("Song cached successfully.", "key", key)
 

--- a/internal/track/fetcher.go
+++ b/internal/track/fetcher.go
@@ -53,6 +53,13 @@ func WithFetcherSongQuality(quality service.SongQualityLevel) Option {
 }
 
 func (f *fetcher) FetchPlayableInfo(ctx context.Context, songID int64) (*netease.PlayableInfo, error) {
+	// ctx 未传入底层（netease 包暂不支持取消）；至少确认调用方未取消，
+	// 避免应用退出后继续进行中的请求
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 	info, err := netease.FetchPlayableInfo(songID, f.quality)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch playable info for song %d: %w", songID, err)
@@ -78,6 +85,11 @@ func (f *fetcher) FetchStream(ctx context.Context, source PlayableSource) (io.Re
 }
 
 func (f *fetcher) FetchLyric(ctx context.Context, songID int64) (structs.LRCData, error) {
+	select {
+	case <-ctx.Done():
+		return structs.LRCData{}, ctx.Err()
+	default:
+	}
 	lrcData, err := netease.FetchLyric(songID)
 	if err != nil {
 		return structs.LRCData{}, errors.Wrapf(err, "failed to fetch lyric for song %d", songID)
@@ -86,6 +98,11 @@ func (f *fetcher) FetchLyric(ctx context.Context, songID int64) (structs.LRCData
 }
 
 func (f *fetcher) FetchCloudLyric(ctx context.Context, userID, songID int64) (structs.LRCData, error) {
+	select {
+	case <-ctx.Done():
+		return structs.LRCData{}, ctx.Err()
+	default:
+	}
 	lrcData, err := netease.FetchCloudLyric(userID, songID)
 	if err != nil {
 		return structs.LRCData{}, errors.Wrapf(err, "failed to fetch cloud lyric for song %d", songID)

--- a/utils/struct/structs.go
+++ b/utils/struct/structs.go
@@ -1,12 +1,22 @@
 package _struct
 
 import (
+	"log/slog"
 	"strings"
 
 	"github.com/buger/jsonparser"
 
 	"github.com/go-musicfox/go-musicfox/internal/structs"
 )
+
+// walkArray 遍历 JSON 数组；解析失败（路径缺失/结构不符）时记一条
+// Debug 日志。原来所有 ArrayEach 错误都被忽略，解析失败与"返回空列表"
+// 无法区分，上层只能显示空菜单，排查困难。
+func walkArray(data []byte, fn func(value []byte, dataType jsonparser.ValueType, offset int, err error), keys ...string) {
+	if _, err := jsonparser.ArrayEach(data, fn, keys...); err != nil {
+		slog.Debug("json array parse failed", "keys", keys, "error", err)
+	}
+}
 
 type ResCode uint8
 
@@ -60,7 +70,7 @@ func ReplaceSpecialStr(str string) string {
 
 // GetDailySongs 获取每日歌曲列表
 func GetDailySongs(data []byte) (list []structs.Song) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if song, err := structs.NewSongFromShortNameSongsJson(value); err == nil {
 			list = append(list, song)
 		}
@@ -72,7 +82,7 @@ func GetDailySongs(data []byte) (list []structs.Song) {
 
 // GetRecentSongs 获取每日歌曲列表
 func GetRecentSongs(data []byte) (list []structs.Song) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, _ error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, _ error) {
 		if t, _ := jsonparser.GetString(value, "resourceType"); t != "SONG" {
 			return
 		}
@@ -95,7 +105,7 @@ func GetRecentSongs(data []byte) (list []structs.Song) {
 // GetDailyPlaylists 获取每日推荐歌单
 func GetDailyPlaylists(data []byte) (list []structs.Playlist) {
 
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if playlist, err := structs.NewPlaylistFromJson(value); err == nil {
 			list = append(list, playlist)
 		}
@@ -106,7 +116,7 @@ func GetDailyPlaylists(data []byte) (list []structs.Playlist) {
 
 // GetSongsOfPlaylist 获取播放列表的歌曲
 func GetSongsOfPlaylist(data []byte) (list []structs.Song) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if song, err := structs.NewSongFromShortNameSongsJson(value); err == nil {
 			list = append(list, song)
 		}
@@ -123,7 +133,7 @@ func GetSongsOfAlbum(data []byte) (list []structs.Song) {
 		album = parsedAlbum
 	}
 
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if song, err := structs.NewSongFromAlbumSongsJson(value); err == nil {
 			if song.PicUrl == "" && album.PicUrl != "" {
 				song.Album.PicUrl = album.PicUrl
@@ -139,7 +149,7 @@ func GetSongsOfAlbum(data []byte) (list []structs.Song) {
 // GetPlaylists 获取播放列表
 func GetPlaylists(data []byte) (list []structs.Playlist) {
 
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if playlist, err := structs.NewPlaylistFromJson(value); err == nil {
 			list = append(list, playlist)
 		}
@@ -151,7 +161,7 @@ func GetPlaylists(data []byte) (list []structs.Playlist) {
 // GetPlaylistsFromHighQuality 获取精品歌单
 func GetPlaylistsFromHighQuality(data []byte) (list []structs.Playlist) {
 
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if playlist, err := structs.NewPlaylistFromJson(value); err == nil {
 			list = append(list, playlist)
 		}
@@ -162,7 +172,7 @@ func GetPlaylistsFromHighQuality(data []byte) (list []structs.Playlist) {
 
 // GetFmSongs 获取每日歌曲列表
 func GetFmSongs(data []byte) (list []structs.Song) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if song, err := structs.NewSongFromCommonJson(value); err == nil {
 			list = append(list, song)
 		}
@@ -173,7 +183,7 @@ func GetFmSongs(data []byte) (list []structs.Song) {
 
 // GetSimiSongs 获取相似歌曲列表
 func GetSimiSongs(data []byte) (list []structs.Song) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if song, err := structs.NewSongFromCommonJson(value); err == nil {
 			list = append(list, song)
 		}
@@ -184,7 +194,7 @@ func GetSimiSongs(data []byte) (list []structs.Song) {
 
 // GetIntelligenceSongs 获取心动模式歌曲列表
 func GetIntelligenceSongs(data []byte) (list []structs.Song) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if song, err := structs.NewSongFromIntelligenceJson(value); err == nil {
 			list = append(list, song)
 		}
@@ -196,7 +206,7 @@ func GetIntelligenceSongs(data []byte) (list []structs.Song) {
 
 // GetNewAlbums 获取最新专辑列表
 func GetNewAlbums(data []byte) (albums []structs.Album) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 
 		if album, err := structs.NewAlbumFromAlbumJson(value); err == nil {
 			albums = append(albums, album)
@@ -209,7 +219,7 @@ func GetNewAlbums(data []byte) (albums []structs.Album) {
 
 // GetAlbumsSublist 获取收藏专辑列表
 func GetAlbumsSublist(data []byte) (albums []structs.Album) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 
 		if album, err := structs.NewAlbumFromAlbumJson(value); err == nil {
 			albums = append(albums, album)
@@ -222,7 +232,7 @@ func GetAlbumsSublist(data []byte) (albums []structs.Album) {
 
 // GetTopAlbums 获取专辑列表
 func GetTopAlbums(data []byte) (albums []structs.Album) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 
 		if album, err := structs.NewAlbumFromAlbumJson(value); err == nil {
 			albums = append(albums, album)
@@ -235,7 +245,7 @@ func GetTopAlbums(data []byte) (albums []structs.Album) {
 
 // GetArtistHotAlbums 获取歌手热门专辑列表
 func GetArtistHotAlbums(data []byte) (albums []structs.Album) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 
 		if album, err := structs.NewAlbumFromAlbumJson(value); err == nil {
 			albums = append(albums, album)
@@ -248,7 +258,7 @@ func GetArtistHotAlbums(data []byte) (albums []structs.Album) {
 
 // GetSongsOfSearchResult 获取搜索结果的歌曲
 func GetSongsOfSearchResult(data []byte) (list []structs.Song) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if song, err := structs.NewSongFromShortNameSongsJson(value); err == nil {
 			list = append(list, song)
 		}
@@ -260,7 +270,7 @@ func GetSongsOfSearchResult(data []byte) (list []structs.Song) {
 
 // GetAlbumsOfSearchResult 获取搜索结果的专辑
 func GetAlbumsOfSearchResult(data []byte) (list []structs.Album) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if album, err := structs.NewAlbumFromAlbumJson(value); err == nil {
 			list = append(list, album)
 		}
@@ -272,7 +282,7 @@ func GetAlbumsOfSearchResult(data []byte) (list []structs.Album) {
 
 // GetPlaylistsOfSearchResult 获取搜索结果的歌单
 func GetPlaylistsOfSearchResult(data []byte) (list []structs.Playlist) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if playlist, err := structs.NewPlaylistFromJson(value); err == nil {
 			list = append(list, playlist)
 		}
@@ -284,7 +294,7 @@ func GetPlaylistsOfSearchResult(data []byte) (list []structs.Playlist) {
 
 // GetArtistsOfSearchResult 获取搜索结果的歌手
 func GetArtistsOfSearchResult(data []byte) (list []structs.Artist) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if artist, err := structs.NewArtist(value); err == nil {
 			list = append(list, artist)
 		}
@@ -296,7 +306,7 @@ func GetArtistsOfSearchResult(data []byte) (list []structs.Artist) {
 
 // GetArtistsOfTopArtists 获取热门歌手
 func GetArtistsOfTopArtists(data []byte) (list []structs.Artist) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if artist, err := structs.NewArtist(value); err == nil {
 			list = append(list, artist)
 		}
@@ -308,7 +318,7 @@ func GetArtistsOfTopArtists(data []byte) (list []structs.Artist) {
 
 // GetArtistsSublist 获取收藏歌手
 func GetArtistsSublist(data []byte) (list []structs.Artist) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if artist, err := structs.NewArtist(value); err == nil {
 			list = append(list, artist)
 		}
@@ -320,7 +330,7 @@ func GetArtistsSublist(data []byte) (list []structs.Artist) {
 
 // GetSongsOfArtist 获取歌手的歌曲
 func GetSongsOfArtist(data []byte) (list []structs.Song) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if song, err := structs.NewSongFromArtistSongsJson(value); err == nil {
 			list = append(list, song)
 		}
@@ -332,7 +342,7 @@ func GetSongsOfArtist(data []byte) (list []structs.Song) {
 
 // GetUsersOfSearchResult 从搜索结果中获取用户列表
 func GetUsersOfSearchResult(data []byte) (list []structs.User) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if song, err := structs.NewUserFromSearchResultJson(value); err == nil {
 			list = append(list, song)
 		}
@@ -344,7 +354,7 @@ func GetUsersOfSearchResult(data []byte) (list []structs.User) {
 
 // GetDjRadiosOfSearchResult 从搜索结果中获取电台列表
 func GetDjRadiosOfSearchResult(data []byte) (list []structs.DjRadio) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if radio, err := structs.NewDjRadioFromJson(value); err == nil {
 			list = append(list, radio)
 		}
@@ -356,7 +366,7 @@ func GetDjRadiosOfSearchResult(data []byte) (list []structs.DjRadio) {
 
 // GetDjRadios 获取电台列表
 func GetDjRadios(data []byte) (list []structs.DjRadio) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if radio, err := structs.NewDjRadioFromJson(value); err == nil {
 			list = append(list, radio)
 		}
@@ -368,7 +378,7 @@ func GetDjRadios(data []byte) (list []structs.DjRadio) {
 
 // GetDjRadiosOfToday 获取今日优选电台列表
 func GetDjRadiosOfToday(data []byte) (list []structs.DjRadio) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if radio, err := structs.NewDjRadioFromJson(value); err == nil {
 			list = append(list, radio)
 		}
@@ -380,7 +390,7 @@ func GetDjRadiosOfToday(data []byte) (list []structs.DjRadio) {
 
 // GetDjRadiosOfTopDj 获取热门电台列表
 func GetDjRadiosOfTopDj(data []byte) (list []structs.DjRadio) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if radio, err := structs.NewDjRadioFromJson(value); err == nil {
 			list = append(list, radio)
 		}
@@ -392,7 +402,7 @@ func GetDjRadiosOfTopDj(data []byte) (list []structs.DjRadio) {
 
 // GetSongsOfDjRadio 获取电台节目列表的歌曲
 func GetSongsOfDjRadio(data []byte) (list []structs.Song) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if song, err := structs.NewSongFromDjRadioProgramJson(value); err == nil {
 			list = append(list, song)
 		}
@@ -403,7 +413,7 @@ func GetSongsOfDjRadio(data []byte) (list []structs.Song) {
 
 // GetSongsOfDjRank 获取电台节目排行榜列表的歌曲
 func GetSongsOfDjRank(data []byte) (list []structs.Song) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if song, err := structs.NewSongFromDjRankProgramJson(value); err == nil {
 			list = append(list, song)
 		}
@@ -414,7 +424,7 @@ func GetSongsOfDjRank(data []byte) (list []structs.Song) {
 
 // GetSongsOfDjHoursRank 获取电台节目24小时排行榜列表的歌曲
 func GetSongsOfDjHoursRank(data []byte) (list []structs.Song) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if song, err := structs.NewSongFromDjRankProgramJson(value); err == nil {
 			list = append(list, song)
 		}
@@ -426,7 +436,7 @@ func GetSongsOfDjHoursRank(data []byte) (list []structs.Song) {
 // GetRanks 获取排行榜
 func GetRanks(data []byte) (list []structs.Rank) {
 
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if rank, err := structs.NewRankFromJson(value); err == nil {
 			list = append(list, rank)
 		}
@@ -437,7 +447,7 @@ func GetRanks(data []byte) (list []structs.Rank) {
 
 // GetSongsOfCloud 获取云盘的歌曲
 func GetSongsOfCloud(data []byte) (list []structs.Song) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if song, err := structs.NewSongFromCloudJson(value); err == nil {
 			list = append(list, song)
 		}
@@ -448,7 +458,7 @@ func GetSongsOfCloud(data []byte) (list []structs.Song) {
 
 // GetDjCategory 获取电台分类
 func GetDjCategory(data []byte) (list []structs.DjCategory) {
-	_, _ = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	walkArray(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if cate, err := structs.NewDjCategoryFromJson(value); err == nil {
 			list = append(list, cate)
 		}

--- a/vendor/github.com/go-musicfox/netease-music/util/request.go
+++ b/vendor/github.com/go-musicfox/netease-music/util/request.go
@@ -27,6 +27,10 @@ const (
 	iosAppVersion = "9.0.65"
 )
 
+// apiPathPattern 匹配 /api/ /weapi/ /eapi/ 等路径段，每次请求
+// regexp.Compile 同一正则纯属浪费
+var apiPathPattern = regexp.MustCompile(`/\w*api/`)
+
 var (
 	globalDeviceId string
 	deviceIdOnce   sync.Once
@@ -166,13 +170,11 @@ func CreateRequest(method, url string, data map[string]string, options *Options)
 	if options.Crypto == "weapi" {
 		data["csrf_token"] = csrfToken
 		data = Weapi(data)
-		reg, _ := regexp.Compile(`/\w*api/`)
-		url = reg.ReplaceAllString(url, "/weapi/")
+		url = apiPathPattern.ReplaceAllString(url, "/weapi/")
 	} else if options.Crypto == "linuxapi" {
 		linuxApiData := make(map[string]interface{}, 3)
 		linuxApiData["method"] = method
-		reg, _ := regexp.Compile(`/\w*api/`)
-		linuxApiData["url"] = reg.ReplaceAllString(url, "/api/")
+		linuxApiData["url"] = apiPathPattern.ReplaceAllString(url, "/api/")
 		linuxApiData["params"] = data
 		data = Linuxapi(linuxApiData)
 		req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36")
@@ -182,7 +184,6 @@ func CreateRequest(method, url string, data map[string]string, options *Options)
 		for key, value := range data {
 			eapiData[key] = value
 		}
-		rand.Seed(time.Now().UnixNano())
 		header := map[string]string{
 			"osver":       osver,
 			"deviceId":    deviceId,
@@ -209,8 +210,7 @@ func CreateRequest(method, url string, data map[string]string, options *Options)
 		}
 		eapiData["header"] = header
 		data = Eapi(options.Url, eapiData)
-		reg, _ := regexp.Compile(`/\w*api/`)
-		url = reg.ReplaceAllString(url, "/eapi/")
+		url = apiPathPattern.ReplaceAllString(url, "/eapi/")
 	}
 
 	var (
@@ -271,7 +271,10 @@ func CreateRequest(method, url string, data map[string]string, options *Options)
 
 	resCode, err = jsonparser.GetFloat(resResp, "code")
 	if err != nil {
-		resCode = 200
+		// 响应没有 code 字段：风控/网关可能返回 HTML、空体或非 JSON 错误。
+		// 不能默认当 200——上层会拿到空结果且无任何错误提示，用户看到
+		// "歌单为空" 而不是 "请求被拦截"。
+		resCode = 520
 	}
 	return
 }


### PR DESCRIPTION
见 #630 的 API 组：FetchLikeSongs 空列表守卫、缺失 code 报 520、缓存锁外拷贝、歌单搜索死循环保护、MPRIS 音量钳制、regexp 提升+ctx 传播、json 解析错误日志、macOS 媒体键幂等注册。