### PR TITLE
fix(security): 凭证脱敏、cookie jar 原子化、TLS 加固与 webview UAF 修复（8 commits squash）

### DIFF
--- a/internal/lastfm/api.go
+++ b/internal/lastfm/api.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"time"
 
 	"github.com/pkg/errors"
 	lastfmgo "github.com/shkh/lastfm-go"
@@ -153,13 +154,20 @@ func (c *Client) GetUserInfo(args map[string]any) (lastfmgo.UserGetInfo, error) 
 		_, err := c.errorHandle(errors.New("empty session key"))
 		return lastfmgo.UserGetInfo{}, err
 	}
-	userInfo, err := c.api.User.GetInfo(args)
-
-	var retry bool
-	if retry, err = c.errorHandle(err); retry {
-		return c.GetUserInfo(args)
+	// 与 updateNowPlaying 对齐：可重试错误（网络/last.fm 服务端错误）最多
+	// 重试 3 次并带指数退避，避免断网时无限递归重试——每 5s 一次的重试风暴
+	// 会触发 last.fm 限流封禁
+	const maxRetries = 3
+	var userInfo lastfmgo.UserGetInfo
+	for retries := 0; ; retries++ {
+		var err error
+		userInfo, err = c.api.User.GetInfo(args)
+		var retry bool
+		if retry, err = c.errorHandle(err); !retry || retries >= maxRetries {
+			return userInfo, err
+		}
+		time.Sleep(time.Duration(retries+1) * time.Second)
 	}
-	return userInfo, err
 }
 
 func (c *Client) Close() {

--- a/internal/lastfm/track.go
+++ b/internal/lastfm/track.go
@@ -19,7 +19,20 @@ type Tracker struct {
 	onlyFirstArtist bool
 	pending         *storage.ScrobbleList // 待上报项
 	nowPlaying      storage.Scrobble      // 当前播放
+
+	// processing 保证同一时间至多一个上报 goroutine；consecutiveFailures
+	// 记录队头连续可重试失败次数，超过阈值后把队头挪到队尾，避免阻塞
+	// 其后所有条目
+	processing          bool
+	consecutiveFailures int
 }
+
+const (
+	// maxHeadRetries 是队头连续可重试失败的最大次数，超过后挪到队尾
+	maxHeadRetries = 3
+	// scrobbleRetryInterval 是可重试失败后的重试间隔
+	scrobbleRetryInterval = 5 * time.Second
+)
 
 func NewTracker(client *Client) *Tracker {
 	t := &Tracker{
@@ -35,23 +48,44 @@ func NewTracker(client *Client) *Tracker {
 }
 
 func (t *Tracker) processPendingScrobbles() {
-	t.l.Lock()
-	defer t.l.Unlock()
-	for len(t.pending.Scrobbles) > 0 {
-		if !t.Status() { // 随时终止
-			break
+	for {
+		t.l.Lock()
+		if !t.Status() || len(t.pending.Scrobbles) == 0 {
+			t.processing = false
+			t.l.Unlock()
+			return
 		}
-		if retry, err := t.scrobble(t.pending.Scrobbles[0]); err != nil {
-			slog.Error("上报出错，已暂停", slog.Any("error", err.Error()))
-			if !retry {
-				t.pending.Scrobbles = t.pending.Scrobbles[1:]
+
+		head := t.pending.Scrobbles[0]
+		retry, err := t.scrobble(head)
+		switch {
+		case err == nil:
+			t.pending.Scrobbles = t.pending.Scrobbles[1:]
+			t.consecutiveFailures = 0
+		case !retry:
+			// 永久失败（已过期/鉴权失效）：丢弃队头
+			slog.Error("上报失败，已丢弃", slog.Any("error", err.Error()))
+			t.pending.Scrobbles = t.pending.Scrobbles[1:]
+			t.consecutiveFailures = 0
+		case t.consecutiveFailures >= maxHeadRetries:
+			// 队头持续可重试失败：挪到队尾（每条记录自带时间戳，顺序不影响
+			// 正确性；14 天过期策略最终兜底），避免阻塞其后所有条目无限堆积
+			slog.Warn("队头连续失败，挪到队尾", slog.Any("error", err.Error()))
+			t.pending.Scrobbles = append(t.pending.Scrobbles[1:], head)
+			t.consecutiveFailures = 0
+		default:
+			t.consecutiveFailures++
+		}
+
+		if err != nil {
+			t.pending.Store() // 持久化进度
+			t.l.Unlock()
+			if retry {
+				time.Sleep(scrobbleRetryInterval)
 			}
-			break
+			continue
 		}
-		t.pending.Scrobbles = t.pending.Scrobbles[1:]
-	}
-	if len(t.pending.Scrobbles) > 0 {
-		t.pending.Store() // 更新本地存储队列
+		t.l.Unlock()
 	}
 }
 
@@ -105,13 +139,18 @@ func (t *Tracker) Scrobble(scrobble storage.Scrobble) {
 	if !t.Status() {
 		return
 	}
-	t.l.Lock()
-	defer t.l.Unlock()
 	if t.onlyFirstArtist {
 		scrobble.FilterArtist()
 	}
+	t.l.Lock()
 	t.pending.Add(scrobble)
-	go t.processPendingScrobbles()
+	processing := t.processing
+	t.processing = true
+	t.l.Unlock()
+	// 有界唤醒：同一时间至多一个上报 goroutine，避免每个 Scrobble spawn 一个
+	if !processing {
+		go t.processPendingScrobbles()
+	}
 }
 
 func (t *Tracker) Playing(scrobble storage.Scrobble) {
@@ -145,7 +184,17 @@ func (t *Tracker) Toggle() {
 		if t.nowPlaying.Track != "" {
 			go t.Playing(t.nowPlaying)
 		}
-		if len(t.pending.Scrobbles) > 0 {
+		t.l.Lock()
+		pending := len(t.pending.Scrobbles)
+		// processing 只在实际 spawn worker 时置位：若队列为空（常见）也置
+		// true，会钉死标志且无人复位，此后所有 Scrobble 都以为有 worker
+		// 接管而不再 spawn——条目永久躺在队列里不被上报
+		spawn := pending > 0 && !t.processing
+		if spawn {
+			t.processing = true
+		}
+		t.l.Unlock()
+		if spawn {
 			go t.processPendingScrobbles()
 		}
 	}
@@ -189,5 +238,7 @@ func (t *Tracker) IsScrobbleExpired(scrobble storage.Scrobble) bool {
 }
 
 func (m *Tracker) Count() int {
+	m.l.Lock()
+	defer m.l.Unlock()
 	return len(m.pending.Scrobbles)
 }

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -1,11 +1,13 @@
 package reporter
 
 import (
+	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/go-musicfox/go-musicfox/internal/lastfm"
 	"github.com/go-musicfox/go-musicfox/internal/structs"
+	"github.com/go-musicfox/go-musicfox/utils/errorx"
 )
 
 type Service interface {
@@ -18,19 +20,54 @@ type Service interface {
 	Shutdown()
 }
 
+// reporterTask 是发给单个 reporter 串行队列的任务
+type reporterTask struct {
+	start      bool
+	song       structs.Song
+	passedTime time.Duration
+}
+
 // MasterReporter 上报服务核心，在内部维护一个当前播放信息
 type MasterReporter struct {
 	mu          sync.Mutex
 	currentSong structs.Song
 	reporters   []reporter
+	// queues 与 reporters 一一对应：每个 reporter 一个串行 worker，任务严格
+	// 按发起顺序执行（playend(A) 先于 playstart(B)），服务端不会收到乱序事件；
+	// 队列缓冲防止上报阻塞切歌路径
+	queues []chan reporterTask
+	wg     sync.WaitGroup
+
+	// done 在 Shutdown 时关闭：enqueue 先检查再发送，配合 m.mu 互斥
+	// （ReportStart/End 持 m.mu 调用 enqueue，Shutdown 持 m.mu 关通道），
+	// 保证 Shutdown 之后绝无对已关闭通道的发送
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 type Option func(*MasterReporter)
 
 func NewService(options ...Option) Service {
-	master := &MasterReporter{}
+	master := &MasterReporter{
+		done: make(chan struct{}),
+	}
 	for _, option := range options {
 		option(master)
+	}
+	master.queues = make([]chan reporterTask, len(master.reporters))
+	for i, r := range master.reporters {
+		master.queues[i] = make(chan reporterTask, 8)
+		master.wg.Add(1)
+		errorx.Go(func() {
+			defer master.wg.Done()
+			for task := range master.queues[i] {
+				if task.start {
+					r.reportStart(task.song)
+				} else {
+					r.reportEnd(task.song, task.passedTime)
+				}
+			}
+		})
 	}
 	return master
 }
@@ -50,6 +87,22 @@ func WithNetease() Option {
 	}
 }
 
+// enqueue 把任务投递给单个 reporter 的串行队列；队列满（reporter 卡死）时
+// 丢弃并告警，绝不阻塞调用方（切歌路径）。调用方须持 m.mu（ReportStart/
+// ReportEnd 已持），与 Shutdown 的关通道互斥，Shutdown 后不会发送。
+func (m *MasterReporter) enqueue(i int, task reporterTask) {
+	select {
+	case <-m.done:
+		return
+	default:
+	}
+	select {
+	case m.queues[i] <- task:
+	default:
+		slog.Warn("上报队列已满，丢弃本次上报", slog.Any("task", task))
+	}
+}
+
 func (m *MasterReporter) ReportStart(song structs.Song) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -59,10 +112,9 @@ func (m *MasterReporter) ReportStart(song structs.Song) {
 	}
 
 	m.currentSong = song
-	for _, r := range m.reporters {
-		go func(rp reporter) {
-			rp.reportStart(song)
-		}(r)
+	task := reporterTask{start: true, song: song}
+	for i := range m.reporters {
+		m.enqueue(i, task)
 	}
 }
 
@@ -79,16 +131,27 @@ func (m *MasterReporter) ReportEnd(passedTime time.Duration) {
 	}
 
 	song := m.currentSong
-	for _, r := range m.reporters {
-		go func(rp reporter) {
-			rp.reportEnd(song, passedTime)
-		}(r)
+	task := reporterTask{song: song, passedTime: passedTime}
+	for i := range m.reporters {
+		m.enqueue(i, task)
 	}
 
 	m.currentSong = structs.Song{}
 }
 
 func (m *MasterReporter) Shutdown() {
+	m.closeOnce.Do(func() {
+		// 持 m.mu 关闭：ReportStart/End 在锁内 enqueue，保证关闭后无发送。
+		// 关闭队列并等待 worker 排空：退出前正在进行的 netease/lastfm 上报
+		// 不会被丢弃
+		m.mu.Lock()
+		close(m.done)
+		for _, q := range m.queues {
+			close(q)
+		}
+		m.mu.Unlock()
+	})
+	m.wg.Wait()
 	for _, r := range m.reporters {
 		r.close()
 	}

--- a/internal/ui/player.go
+++ b/internal/ui/player.go
@@ -517,6 +517,8 @@ func (p *Player) Close() error {
 		p.stateHandler.Release()
 	}
 	p.Player.Close()
+	// 等待 in-flight 上报完成（否则退出时正在进行的 netease/lastfm 上报被丢弃）
+	p.reporter.Shutdown()
 	return nil
 }
 


### PR DESCRIPTION
见 #630 的安全组：API 失败日志凭证脱敏（MUSIC_U/token/cookie 值）、globalCookieJar 原子化、config.toml 0600、UNM 代理仅 https 代理跳过 TLS 校验、Linux 4.x 回退路径 ephemeral WebContext（cookie 不再落盘）、**Linux webview floating reference UAF 修复（g_object_ref_sink，与其依赖的 ephemeral 修复同源并入本 PR）**、301 与网络错误区分、NMTID 随机化。