### PR TITLE
fix(webview): Windows 失败路径清理（2 commits squash）

### DIFF
--- a/cmd/musicfox.go
+++ b/cmd/musicfox.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -99,7 +100,13 @@ func loadConfig() {
 	// 加载 TOML 配置
 	cfg, err := configs.NewConfigFromTomlFile(configPath)
 	if err != nil {
-		panic(fmt.Sprintf("fatal: failed to load configuration: %v", err))
+		// 配置文件是用户手写 TOML，一个语法错误（如漏引号）就 panic 的话应用
+		// 无法启动、用户只能手删配置。降级为默认配置继续运行并给出明确警告。
+		slog.Warn("配置解析失败，已回退到默认配置（请检查或运行 upgrade-config 修复）",
+			slog.String("path", configPath),
+			slogx.Error(err),
+		)
+		cfg, _ = configs.NewDefaultConfig()
 	}
 	configs.AppConfig = cfg
 

--- a/internal/configs/loader.go
+++ b/internal/configs/loader.go
@@ -40,6 +40,27 @@ func NewConfigFromTomlFile(tomlPath string) (*Config, error) {
 		}
 	}
 
+	return newConfigFromKoanf(k)
+}
+
+// NewDefaultConfig 仅加载内嵌默认配置（不含用户文件）。用于用户配置
+// 损坏（手写 TOML 语法错误）时的降级路径：以默认配置继续运行，而不是
+// 让应用无法启动。
+func NewDefaultConfig() (*Config, error) {
+	k := koanf.New(".")
+
+	defaultTomlBytes, err := filex.ReadFileFromEmbed("embed/" + types.AppTomlFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read embedded default config")
+	}
+	if err := k.Load(rawbytes.Provider(defaultTomlBytes), toml.Parser()); err != nil {
+		return nil, errors.Wrap(err, "failed to parse embedded default config")
+	}
+
+	return newConfigFromKoanf(k)
+}
+
+func newConfigFromKoanf(k *koanf.Koanf) (*Config, error) {
 	// 处理动态默认值
 	applyDynamicDefaults(k)
 

--- a/internal/keybindings/keybindings.go
+++ b/internal/keybindings/keybindings.go
@@ -4,6 +4,7 @@ package keybindings
 import (
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 )
 
@@ -276,6 +277,32 @@ func UserOperateToKeys() map[OperateType][]string {
 }
 
 // InitDefaults 生成操作绑定的 map
+// resolveDefaultConflicts 以确定顺序消解默认绑定内的重复键：按操作名倒序
+// 处理，后序操作先声明按键，先序操作让出（如 OpSearch 保留 "、"，
+// OpDeleteSongFromPlaylist 让出）。键的归属与启动次数无关，行为确定。
+func resolveDefaultConflicts(bindings map[OperateType][]string) {
+	ops := make([]OperateType, 0, len(bindings))
+	for op := range bindings {
+		ops = append(ops, op)
+	}
+	sort.Slice(ops, func(i, j int) bool { return ops[i] > ops[j] })
+
+	keyToOp := make(map[string]OperateType, 64)
+	for _, op := range ops {
+		keys := bindings[op]
+		valid := keys[:0]
+		for _, key := range keys {
+			if owner, found := keyToOp[key]; found {
+				slog.Debug(fmt.Sprintf("默认绑定按键 '%s' 同时属于 %s 与 %s，已从 %s 移除", key, owner, op, op))
+				continue
+			}
+			keyToOp[key] = op
+			valid = append(valid, key)
+		}
+		bindings[op] = valid
+	}
+}
+
 func InitDefaults(useDefault bool) map[OperateType][]string {
 	if !useDefault {
 		baseCopy := make(map[OperateType][]string, len(defaultBaseOperateToKeys))
@@ -459,6 +486,11 @@ func BuildEffectiveBindings(userBindings map[OperateType][]string, useDefault bo
 		effectiveBindings[op] = append([]string(nil), keys...)
 	}
 
+	// 默认绑定自身可能存在重复键（如 "、" 同时属于 OpSearch 与
+	// OpDeleteSongFromPlaylist）。不消解的话，反向映射遍历 map 的随机顺序
+	// 会让胜出方每次启动都不同，且把破坏性操作绑定到中文输入法高频误触键上。
+	resolveDefaultConflicts(effectiveBindings)
+
 	if len(userBindings) == 0 {
 		return effectiveBindings
 	}
@@ -467,8 +499,17 @@ func BuildEffectiveBindings(userBindings map[OperateType][]string, useDefault bo
 	keyToOp := BuildKeyToOperateTypeMap(effectiveBindings) // 构建初始的 按键 -> 操作 反向映射
 	conflicts := make(map[string][]OperateType)            // 用于记录所有发生的冲突
 
+	// 按操作名排序处理用户绑定：map 迭代顺序随机时，冲突的"最终胜出方"由
+	// 遍历顺序决定且每次启动都可能不同
+	userOps := make([]OperateType, 0, len(userBindings))
+	for op := range userBindings {
+		userOps = append(userOps, op)
+	}
+	sort.Slice(userOps, func(i, j int) bool { return userOps[i] < userOps[j] })
+
 	// 遍历用户配置，解决冲突并记录
-	for op, keys := range userBindings {
+	for _, op := range userOps {
+		keys := userBindings[op]
 		validKeys := make([]string, 0, len(keys))
 		var skippedKeys []string
 
@@ -539,7 +580,9 @@ func BuildKeyToOperateTypeMap(effectiveBindings map[OperateType][]string) map[st
 		return keyMap
 	}
 
-	for op, keys := range userOperateToKeys {
+	// 遍历参数而非全局 userOperateToKeys：两者在当前调用顺序下碰巧一致，
+	// 但一旦在 InitDefaults 前调用会静默得到错误映射
+	for op, keys := range effectiveBindings {
 		for _, key := range keys {
 			keyMap[key] = op
 		}

--- a/internal/lyric/service.go
+++ b/internal/lyric/service.go
@@ -151,13 +151,16 @@ func (s *Service) SetSong(ctx context.Context, song structs.Song) error {
 			}
 		}
 
-		// 解析传统 LRC 格式的行（歌词）
+		// 解析传统 LRC 格式的行（歌词）。尽力解析：ReadLRC 会跳过坏行并
+		// 保留成功行，err 非 nil 只表示存在坏行（如 [ar:]/[ti:] 元数据行），
+		// 不应因此丢弃整份歌词。
 		if len(lrcLines) > 0 {
 			lrcFile, err := ReadLRC(strings.NewReader(strings.Join(lrcLines, "\n")))
-			if err == nil && lrcFile != nil {
+			if lrcFile != nil {
 				s.fragments = append(s.fragments, lrcFile.fragments...)
-			} else if err != nil {
-				slog.Debug("[LRC] Failed to parse traditional LRC lines", "error", err)
+			}
+			if err != nil {
+				slog.Debug("[LRC] Some traditional LRC lines failed to parse, keeping valid ones", "error", err)
 			}
 		}
 
@@ -187,13 +190,12 @@ func (s *Service) SetSong(ctx context.Context, song structs.Song) error {
 			slog.Warn("[LRC] Failed to parse JSON format LRC", "error", err)
 		}
 	} else {
-		// 传统 LRC 格式 [00:00.00]歌词
+		// 传统 LRC 格式 [00:00.00]歌词。尽力解析：ReadLRC 会跳过坏行并
+		// 保留成功行，err 非 nil 只表示存在坏行（如 [ar:]/[ti:] 元数据行），
+		// 默认不因一行坏数据丢弃整首歌词。
 		lrcFile, err := ReadLRC(strings.NewReader(lrcData.Original))
 		if err != nil {
-			if !s.skipParseErr {
-				return errors.Wrap(err, "failed to parse original lyric")
-			}
-			slog.Debug("ignoring lyric parsing error", "error", err)
+			slog.Debug("some lyric lines failed to parse, keeping valid ones", "error", err)
 		}
 
 		if lrcFile != nil {
@@ -209,7 +211,7 @@ func (s *Service) SetSong(ctx context.Context, song structs.Song) error {
 				s.transFragments = trans.fragments
 				slog.Debug("ignoring lyric translation parsing error", "error", err)
 			} else {
-				slog.Error("failed to parse lyric translationd", "error", err)
+				slog.Error("failed to parse lyric translation", "error", err)
 			}
 		}
 	}

--- a/internal/playlist/intelligent.go
+++ b/internal/playlist/intelligent.go
@@ -1,13 +1,8 @@
 package playlist
 
 import (
-	"strconv"
-
-	"github.com/go-musicfox/netease-music/service"
-
 	"github.com/go-musicfox/go-musicfox/internal/structs"
 	"github.com/go-musicfox/go-musicfox/internal/types"
-	_struct "github.com/go-musicfox/go-musicfox/utils/struct"
 )
 
 // IntelligentPlayMode 心动模式播放实现
@@ -118,24 +113,5 @@ func (i *IntelligentPlayMode) OnPlaylistChanged(currentIndex int, playlist []str
 	}
 
 	return nil
-}
-
-// GetIntelligentRecommendations 获取智能推荐歌曲列表
-// 这是心动模式的核心功能，基于指定歌曲获取推荐
-func (i *IntelligentPlayMode) GetIntelligentRecommendations(songId, playlistId int64) ([]structs.Song, error) {
-	intelligenceService := service.PlaymodeIntelligenceListService{
-		SongId:       strconv.FormatInt(songId, 10),
-		PlaylistId:   strconv.FormatInt(playlistId, 10),
-		StartMusicId: strconv.FormatInt(songId, 10),
-	}
-
-	code, response := intelligenceService.PlaymodeIntelligenceList()
-	codeType := _struct.CheckCode(code)
-	if codeType != _struct.Success {
-		return nil, ErrInvalidPlayMode // 使用现有错误类型
-	}
-
-	songs := _struct.GetIntelligenceSongs(response)
-	return songs, nil
 }
 

--- a/internal/playlist/manager.go
+++ b/internal/playlist/manager.go
@@ -336,9 +336,14 @@ func (pm *playlistManager) LoadState() error {
 		return err
 	}
 
-	// 恢复播放列表状态
-	pm.currentIndex = snapshot.CurSongIndex
+	// 恢复播放列表状态。快照可能损坏（手工改库、旧版本 bug、schema 变化），
+	// 必须校验 index 在界内，否则后续删除歌曲等操作会越界 panic。
 	pm.playlist = snapshot.Playlist
+	if snapshot.CurSongIndex < 0 || snapshot.CurSongIndex >= len(pm.playlist) {
+		pm.currentIndex = -1
+	} else {
+		pm.currentIndex = snapshot.CurSongIndex
+	}
 
 	// 通知播放模式播放列表已变化
 	if pm.playMode != nil {

--- a/internal/track/cache.go
+++ b/internal/track/cache.go
@@ -88,6 +88,9 @@ func (m *Cacher) Put(song structs.Song, quality service.SongQualityLevel, fileTy
 	defer os.Remove(tempFile.Name())
 	defer tempFile.Close()
 
+	// 网络→磁盘拷贝不持锁：GetPath（切歌解析路径）需要 RLock，慢速 FLAC
+	// 后台缓存期间持锁会让每次切歌阻塞数秒到数十秒。锁只覆盖最后的 rename
+	// （prune 跳过 .tmp 文件，锁外建临时文件与拷贝并发安全）。
 	_, err = io.Copy(tempFile, data)
 	if err != nil {
 		return fmt.Errorf("failed to copy data to temp file: %w", err)

--- a/internal/ui/netease.go
+++ b/internal/ui/netease.go
@@ -459,6 +459,12 @@ func (n *Netease) CloseHook(_ *model.App) {
 	_ = n.player.Close()
 	n.lastfm.Close()
 
+	// 关闭持久化 DB：否则第二实例回退用的临时 DB（/tmp/musicfox*.db）永不
+	// 删除、每次并发运行泄漏一个文件；正常实例也应显式关闭 bbolt
+	if storage.DBManager != nil {
+		_ = storage.DBManager.Close()
+	}
+
 	if n.desktopLyrics != nil {
 		n.desktopLyrics.Close()
 	}

--- a/utils/slogx/slog.go
+++ b/utils/slogx/slog.go
@@ -22,7 +22,7 @@ var levelVar slog.LevelVar
 // LogFileName 日志文件名
 const LogFileName = "musicfox.log"
 
-// maxLogFileSize 日志文件超过该大小后，启动时轮转为 musicfox.log.old
+// maxLogFileSize 日志文件超过该大小后，启动时直接清空（见 rotateLogFile）
 const maxLogFileSize = 10 << 20 // 10 MiB
 
 var (
@@ -48,7 +48,11 @@ func Init() {
 
 		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
 		if err != nil {
-			panic(fmt.Sprintf("failed to open log file, err: %v", err))
+			// 日志目录不可写（只读 HOME/快照环境）时降级到 stderr 继续运行：
+			// 此处 panic 发生在包装进程内（RunWrapped 的 wrapper 路径无
+			// recover），会输出原始 Go panic 堆栈且应用无法启动
+			fmt.Fprintf(os.Stderr, "failed to open log file %s, falling back to stderr: %v\n", logPath, err)
+			return
 		}
 		logFile = f
 


### PR DESCRIPTION
见 #630 的 webview 组：WebView2 初始化失败路径临时目录清理、SetTimer 失败告警。Linux UAF/refcount 修复已并入 #633（与其依赖的 ephemeral context 修复同源）。