### PR TITLE
fix(security): 凭证脱敏、cookie jar 原子化、TLS 与文件权限加固（7 commits squash）

### DIFF
--- a/internal/configs/framerate.go
+++ b/internal/configs/framerate.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"strconv"
 	"time"
 )
 
@@ -32,5 +33,5 @@ func (f FrameRate) DurationMs() int {
 
 // String returns the string representation of the frame rate (e.g., "30 FPS").
 func (f FrameRate) String() string {
-	return string(rune(f+'0')) + " FPS"
+	return strconv.Itoa(int(f)) + " FPS"
 }

--- a/internal/netease/error.go
+++ b/internal/netease/error.go
@@ -2,6 +2,8 @@ package netease
 
 import (
 	"fmt"
+
+	_struct "github.com/go-musicfox/go-musicfox/utils/struct"
 )
 
 type Error struct {
@@ -13,4 +15,16 @@ func (e Error) Error() string {
 	return fmt.Sprintf("code: %d, msg: %s", e.CodeType, e.Msg)
 }
 
-var NetworkErr = Error{CodeType: -1, Msg: "网络错误"}
+var (
+	NetworkErr   = Error{CodeType: -1, Msg: "网络错误"}
+	NeedLoginErr = Error{CodeType: 301, Msg: "登录已失效，请重新登录"}
+)
+
+// mapResCodeToErr 将 API 响应码映射为错误。登录失效（301）单独区分：
+// 运行时会话过期时用户应看到"请重新登录"而不是误导性的"网络错误"。
+func mapResCodeToErr(codeType _struct.ResCode) error {
+	if codeType == _struct.NeedLogin {
+		return NeedLoginErr
+	}
+	return NetworkErr
+}

--- a/internal/netease/playlist.go
+++ b/internal/netease/playlist.go
@@ -51,7 +51,7 @@ Loop:
 	for {
 		codeType, playlists, hasMore = FetchUserPlaylists(userId, 30, offset)
 		if codeType != _struct.Success {
-			err = NetworkErr
+			err = mapResCodeToErr(codeType)
 			return
 		}
 		offset += len(playlists)
@@ -68,7 +68,7 @@ Loop:
 	}
 	codeType, songs = FetchSongsOfPlaylist(playlistId, getAll)
 	if codeType != _struct.Success {
-		err = NetworkErr
+		err = mapResCodeToErr(codeType)
 		return
 	}
 	return

--- a/internal/netease/song.go
+++ b/internal/netease/song.go
@@ -14,7 +14,7 @@ func FetchDailySongs() (playlist []structs.Song, err error) {
 	code, response := recommendSongs.RecommendSongs()
 	codeType := _struct.CheckCode(code)
 	if codeType != _struct.Success {
-		err = NetworkErr
+		err = mapResCodeToErr(codeType)
 		return
 	}
 	playlist = _struct.GetDailySongs(response)
@@ -50,12 +50,12 @@ func FetchLikeSongs(userId int64, getAll bool) (playlist []structs.Song, err err
 	)
 	codeType, playlists, _ = FetchUserPlaylists(userId, 1, 0)
 	if codeType != _struct.Success {
-		err = NetworkErr
+		err = mapResCodeToErr(codeType)
 		return
 	}
 	codeType, songs = FetchSongsOfPlaylist(playlists[0].Id, getAll)
 	if codeType != _struct.Success {
-		err = NetworkErr
+		err = mapResCodeToErr(codeType)
 		return
 	}
 	playlist = songs

--- a/internal/ui/login_webview_linux.go
+++ b/internal/ui/login_webview_linux.go
@@ -168,12 +168,25 @@ func (c *webviewLoginController) runGTK() {
 		cookieManager uintptr
 		webView       uintptr
 	)
+	// webkit_web_view_new() 返回 floating reference（WebKitWebView 派生自
+	// GInitiallyUnowned）。必须立即 g_object_ref_sink 接管所有权：GtkWindowAddChild
+	// 对非 floating 对象只增计数，于是引用计数变为「我们 1 + 窗口 1」；defer unref
+	// 归还我们的 1，窗口销毁时再归零。若不对 floating 引用做 sink，AddChild 会把它
+	// 吞掉（窗口成为唯一持有者），窗口销毁时 webview 即被释放，随后的 defer unref
+	// 将作用在已释放内存上（use-after-free）。
 	if usesLegacyWebKitAPI(webkitgtk.WebKitGTKVersion()) {
 		// WebKitGTK 4.1 and 4.0 use the WebContext/CookieManager API; 4.1
 		// differs from 4.0 only in its libsoup ABI.
-		ctx := webkitgtk.WebContextGetDefault()
+		// 必须用 ephemeral context：默认 context 是进程级持久单例，WebKit 会把
+		// 登录 cookie（含 MUSIC_U 会话令牌）明文写进 website-data 目录、永不
+		// 清理，违约"登录数据不留痕"契约（6.0 ephemeral session / Windows
+		// 临时目录 / macOS non-persistent store 均遵守）。cookieManager 是
+		// context 的借用引用，ctx 的 unref 注册在最前（LIFO 最后执行）。
+		ctx := webkitgtk.WebContextNewEphemeral()
+		defer webkitgtk.GObjectUnref(ctx)
 		cookieManager = webkitgtk.WebContextGetCookieManager(ctx)
 		webView = webkitgtk.WebViewNew()
+		webkitgtk.GObjectRefSink(webView)
 	} else {
 		session = webkitgtk.NetworkSessionNewEphemeral()
 		// Release our application-side references (transfer-full from the
@@ -185,6 +198,7 @@ func (c *webviewLoginController) runGTK() {
 		defer webkitgtk.GObjectUnref(session)
 		cookieManager = webkitgtk.NetworkSessionGetCookieManager(session)
 		webView = webkitgtk.WebViewNewWithNetworkSession(session)
+		webkitgtk.GObjectRefSink(webView)
 	}
 	defer webkitgtk.GObjectUnref(webView)
 	window := webkitgtk.GtkWindowNew()

--- a/internal/webkitgtk/webkitgtk.go
+++ b/internal/webkitgtk/webkitgtk.go
@@ -62,6 +62,7 @@ var (
 var (
 	webkitWebViewNew                    func() uintptr
 	webkitWebContextGetDefault          func() uintptr
+	webkitWebContextNewEphemeral        func() uintptr
 	webkitWebContextGetCookieManager    func(ctx uintptr) uintptr
 	webkitCookieManagerGetCookies       func(manager uintptr, uri *byte, cancellable, callback, userData uintptr)
 	webkitCookieManagerGetCookiesFinish func(manager, result, err uintptr) uintptr
@@ -96,6 +97,7 @@ var (
 var (
 	gSignalConnectData func(instance uintptr, detailedSignal *byte, cHandler, data, destroyData uintptr, connectFlags int32) uint
 	gObjectUnref       func(object uintptr)
+	gObjectRefSink     func(object uintptr) uintptr
 	gTimeoutAdd        func(interval uint32, function, data uintptr) uint
 	gListLength        func(list uintptr) uint
 	gListNthData       func(list uintptr, n uint) uintptr
@@ -126,6 +128,7 @@ func init() {
 		dlopen("libgobject-2.0.so.0", func(lib uintptr) {
 			registerSymbol(&gSignalConnectData, lib, "g_signal_connect_data")
 			registerSymbol(&gObjectUnref, lib, "g_object_unref")
+			registerSymbol(&gObjectRefSink, lib, "g_object_ref_sink")
 			registerSymbol(&gObjectNew, lib, "g_object_new")
 		}) &&
 			dlopen("libglib-2.0.so.0", func(lib uintptr) {
@@ -161,7 +164,7 @@ func init() {
 	}
 	webkitUsableLegacy := func() bool {
 		return webkitWebViewNew != nil &&
-			webkitWebContextGetDefault != nil &&
+			webkitWebContextNewEphemeral != nil &&
 			webkitWebContextGetCookieManager != nil &&
 			webkitWebViewLoadURI != nil &&
 			webkitCookieManagerGetCookies != nil &&
@@ -258,6 +261,7 @@ func registerWebKit(lib uintptr) {
 func registerWebKitLegacy(lib uintptr) {
 	registerSymbol(&webkitWebViewNew, lib, "webkit_web_view_new")
 	registerSymbol(&webkitWebContextGetDefault, lib, "webkit_web_context_get_default")
+	registerSymbol(&webkitWebContextNewEphemeral, lib, "webkit_web_context_new_ephemeral")
 	registerSymbol(&webkitWebContextGetCookieManager, lib, "webkit_web_context_get_cookie_manager")
 	registerSymbol(&webkitWebViewLoadURI, lib, "webkit_web_view_load_uri")
 	registerSymbol(&webkitCookieManagerGetCookies, lib, "webkit_cookie_manager_get_cookies")
@@ -343,6 +347,15 @@ func WebContextGetDefault() uintptr {
 		return 0
 	}
 	return webkitWebContextGetDefault()
+}
+
+// WebContextNewEphemeral creates an ephemeral WebKitWebContext (transfer-full)
+// on the legacy 4.0/4.1 API: cookies and website data never persist to disk.
+func WebContextNewEphemeral() uintptr {
+	if webkitWebContextNewEphemeral == nil {
+		return 0
+	}
+	return webkitWebContextNewEphemeral()
 }
 
 // WebContextGetCookieManager returns the cookie manager (borrowed reference)
@@ -533,6 +546,17 @@ func GObjectUnref(object uintptr) {
 		return
 	}
 	gObjectUnref(object)
+}
+
+// GObjectRefSink 将 floating reference 变为普通引用（g_object_ref_sink）：
+// 对 floating 对象仅取消 floating 标志不增计数，对非 floating 对象增计数。
+// 用于接管构造函数的 floating 所有权（如 webkit_web_view_new），使后续
+// defer unref 与容器持有的引用精确配对。
+func GObjectRefSink(object uintptr) {
+	if gObjectRefSink == nil {
+		return
+	}
+	gObjectRefSink(object)
 }
 
 func GTimeoutAdd(interval uint32, function, data uintptr) uint {

--- a/utils/errorx/wrapper.go
+++ b/utils/errorx/wrapper.go
@@ -34,7 +34,16 @@ func RunWrapped(app func()) {
 	// 恢复 stderr 后再 exec，保证子进程继承到真正的 stderr（终端）。
 	// Windows 上 stderr 无法在进程内重定向，childStderr 经管道双写终端与日志
 	restoreStderr()
-	cmd.Env = append(os.Environ(), childEnv+"=1")
+	// 去重后追加：若用户环境里已存在 childEnv（值非 "1"），getenv 返回首个
+	// 匹配，子进程会把自己当 wrapper 再 exec 一次（理论上的递归 exec）
+	env := os.Environ()
+	for i, e := range env {
+		if strings.HasPrefix(e, childEnv+"=") {
+			env = append(env[:i], env[i+1:]...)
+			break
+		}
+	}
+	cmd.Env = append(env, childEnv+"=1")
 	cmd.Stdin, cmd.Stdout = os.Stdin, os.Stdout
 	cmd.Stderr = childStderr()
 

--- a/utils/filex/file.go
+++ b/utils/filex/file.go
@@ -32,7 +32,10 @@ func CopyFileFromEmbed(src, dst string) error {
 	}
 	defer srcfd.Close()
 
-	if dstfd, err = os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0766); err != nil {
+	// 0600：该文件（config.toml）会写入 neteaseCookie、lastfm key/secret 等
+	// 凭据，0766 在默认 umask 下实际为 0744（group/other 可读），同机其他
+	// 用户可读登录 cookie；与 bbolt 数据库（0600）保持一致
+	if dstfd, err = os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600); err != nil {
 		return err
 	}
 	defer dstfd.Close()
@@ -49,7 +52,7 @@ func CopyDirFromEmbed(src, dst string) error {
 		fds []fs.DirEntry
 	)
 
-	if err = os.MkdirAll(dst, 0766); err != nil {
+	if err = os.MkdirAll(dst, 0700); err != nil {
 		return err
 	}
 	if fds, err = embedDir.ReadDir(src); err != nil {

--- a/utils/netease/songinfo.go
+++ b/utils/netease/songinfo.go
@@ -2,6 +2,7 @@ package netease
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -35,10 +36,15 @@ func FetchPlayableInfo(songID int64, quality service.SongQualityLevel) (Playable
 		Level:   quality,
 		SkipUNM: true,
 	}
-	code, response, _ := urlService.SongUrl()
+	code, response, err := urlService.SongUrl()
 	slog.Debug("fetch song url", "code", code, "response", string(response))
 	if code != 200 {
-		return PlayableInfo{}, errors.New(string(response))
+		// 保留底层错误：网络失败时 response 可能为空，errors.New(string(nil))
+		// 会得到空字符串错误，播放失败时用户看到空白报错
+		if err != nil {
+			return PlayableInfo{}, fmt.Errorf("failed to fetch song url (code %d): %w", code, err)
+		}
+		return PlayableInfo{}, fmt.Errorf("failed to fetch song url (code %d): %s", code, string(response))
 	}
 
 	var (

--- a/vendor/github.com/go-musicfox/netease-music/util/common.go
+++ b/vendor/github.com/go-musicfox/netease-music/util/common.go
@@ -27,10 +27,11 @@ func RandStringRunes(n int) string {
 }
 
 func ApplyRequestStrategy(jar http.CookieJar) {
-	// 注入反风控参数
+	// 注入反风控参数。NMTID 用随机值：固定值会让所有 go-musicfox 用户共享
+	// 同一追踪 ID，易被风控关联（且会覆盖之前随机生成的 NMTID）
 	strategyCookies := []*http.Cookie{
 		{Name: "os", Value: "pc"},
-		{Name: "NMTID", Value: "some_random_id_from_strategy"},
+		{Name: "NMTID", Value: hex.EncodeToString([]byte(RandStringRunes(16)))},
 	}
 	targetUrl, _ := url.Parse("https://music.163.com")
 	jar.SetCookies(targetUrl, strategyCookies)

--- a/vendor/github.com/go-musicfox/netease-music/util/request.go
+++ b/vendor/github.com/go-musicfox/netease-music/util/request.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/buger/jsonparser"
@@ -53,32 +54,38 @@ func chooseUserAgent(ua string) string {
 }
 
 var (
-	globalCookieJar http.CookieJar
+	// globalCookieJar 在登录/刷新 token（UI 线程）与并发 API 请求（tea cmd、
+	// 播放器 goroutine）之间共享。jar 内部（cookiejar.Jar）并发安全，但接口
+	// 变量本身必须原子读写，否则 SetGlobalCookieJar 与每请求读取构成数据竞争
+	// （go run -race 必报，也是登录失效难排查的根源之一）。
+	globalCookieJar atomic.Value // http.CookieJar
 	once            sync.Once
 )
 
 func SetGlobalCookieJar(jar http.CookieJar) {
-	globalCookieJar = jar
+	globalCookieJar.Store(jar)
 }
 
 func GetGlobalCookieJar() http.CookieJar {
 	once.Do(func() {
-		if globalCookieJar == nil {
+		jar, ok := globalCookieJar.Load().(http.CookieJar)
+		if !ok || jar == nil {
 			// 为空时才新建一个jar对象
-			jar, _ := cookiejar.New(nil)
-			globalCookieJar = jar
+			jar, _ = cookiejar.New(nil)
+			globalCookieJar.Store(jar)
 		}
-		if CheckSDeviceId(globalCookieJar) == "" {
+		if CheckSDeviceId(jar) == "" {
 			// jar中没有sDeviceId则生成一个并添加
 			sDeviceId := GenerateSDeviceId()
 			cookieMap := map[string]string{
 				"sDeviceId": sDeviceId,
 			}
 			host := "https://music.163.com"
-			AddCookiesToJar(globalCookieJar, cookieMap, host)
+			AddCookiesToJar(jar, cookieMap, host)
 		}
 	})
-	return globalCookieJar
+	jar, _ := globalCookieJar.Load().(http.CookieJar)
+	return jar
 }
 
 func CookieValueByName(cookies []*http.Cookie, name string, fallback string) string {
@@ -95,10 +102,74 @@ func CookieValueByName(cookies []*http.Cookie, name string, fallback string) str
 	return cookie.Value
 }
 
+// sensitiveKey 判断日志中需要脱敏的字段名
+func sensitiveKey(k string) bool {
+	k = strings.ToLower(k)
+	return strings.Contains(k, "password") || strings.Contains(k, "pwd") ||
+		strings.Contains(k, "token") || strings.Contains(k, "cookie") ||
+		strings.Contains(k, "credit") || strings.Contains(k, "csrf")
+}
+
+// RedactedData 脱敏请求参数中的敏感字段值
+func RedactedData(data map[string]string) map[string]string {
+	if len(data) == 0 {
+		return data
+	}
+	redacted := make(map[string]string, len(data))
+	for k, v := range data {
+		if sensitiveKey(k) {
+			redacted[k] = "[REDACTED]"
+		} else {
+			redacted[k] = v
+		}
+	}
+	return redacted
+}
+
+// RedactedOptions 脱敏 Options 中的 cookie 值与 Token
+func RedactedOptions(options *Options) *Options {
+	if options == nil {
+		return options
+	}
+	redacted := *options
+	redacted.Cookies = RedactedCookies(options.Cookies)
+	if redacted.Token != "" {
+		redacted.Token = "[REDACTED]"
+	}
+	return &redacted
+}
+
+// RedactedCookies 隐藏 cookie 值，仅保留名称
+func RedactedCookies(cookies []*http.Cookie) []*http.Cookie {
+	if len(cookies) == 0 {
+		return cookies
+	}
+	redacted := make([]*http.Cookie, 0, len(cookies))
+	for _, c := range cookies {
+		cp := *c
+		if cp.Value != "" {
+			cp.Value = "[REDACTED]"
+		}
+		redacted = append(redacted, &cp)
+	}
+	return redacted
+}
+
+// TruncateBytes 截断日志中的响应体
+func TruncateBytes(b []byte, max int) string {
+	if len(b) <= max {
+		return string(b)
+	}
+	return string(b[:max]) + "..."
+}
+
 func CreateRequest(method, url string, data map[string]string, options *Options) (resCode float64, resResp []byte, resCookies []*http.Cookie) {
 	defer func() {
 		if resCode != 200 {
-			log.Printf("url: %s, method: %s, reqData: %#v, reqOptions: %+v, resCode: %f, resResp: %s, resCookies: %#v", url, method, data, options, resCode, resResp, resCookies)
+			// 日志脱敏：cookie 值（含 MUSIC_U 等完整会话凭证）、敏感请求字段
+			// 与 Token 不得明文落盘；响应体截断防止大体积内容刷屏
+			log.Printf("url: %s, method: %s, reqData: %#v, reqOptions: %+v, resCode: %f, resResp: %s, resCookies: %#v",
+				url, method, RedactedData(data), RedactedOptions(options), resCode, TruncateBytes(resResp, 512), RedactedCookies(resCookies))
 		}
 	}()
 
@@ -107,10 +178,10 @@ func CreateRequest(method, url string, data map[string]string, options *Options)
 		globalDeviceId = deviceIds[idx]
 	})
 
-	globalCookieJar = GetGlobalCookieJar()
+	jar := GetGlobalCookieJar()
 
 	if u, err := urlpkg.Parse(url); err == nil {
-		options.Cookies = append(options.Cookies, globalCookieJar.Cookies(u)...)
+		options.Cookies = append(options.Cookies, jar.Cookies(u)...)
 	}
 	req := requests.Requests()
 	if len(UNMProxyURL) > 0 {
@@ -135,7 +206,7 @@ func CreateRequest(method, url string, data map[string]string, options *Options)
 		csrfToken   = CookieValueByName(options.Cookies, "__csrf", "")
 	)
 
-	req.Client.Jar = globalCookieJar
+	req.Client.Jar = jar
 	req.Header.Set("User-Agent", chooseUserAgent(options.Ua))
 	req.Header.Set("os", os)
 	req.Header.Set("appver", appver)

--- a/vendor/github.com/go-musicfox/requests/requests.go
+++ b/vendor/github.com/go-musicfox/requests/requests.go
@@ -249,9 +249,17 @@ func (req *Request) Proxy(proxyurl string) {
 		log.Println("Set proxy failed")
 		return
 	}
+	// 仅在代理自身为 TLS（https://，通常自带自签 CA 做 MITM）时跳过证书校验；
+	// 普通 http:// 代理只是隧道，端到端到目标站的 TLS 必须保持校验——否则配置
+	// UNM 代理后到 music.163.com 的全部流量（含登录 cookie）可被任意代理
+	// 透明 MITM（域名正确也无感知）。
+	var tlsConfig *tls.Config
+	if urlproxy.Scheme == "https" {
+		tlsConfig = &tls.Config{InsecureSkipVerify: true}
+	}
 	req.Client.Transport = &http.Transport{
 		Proxy:           http.ProxyURL(urlproxy),
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: tlsConfig,
 	}
 
 }


### PR DESCRIPTION
见 #630 的安全组：API 失败日志凭证脱敏（MUSIC_U/token/cookie 值）、globalCookieJar 原子化、config.toml 0600、UNM 代理仅 https 代理跳过 TLS 校验、Linux 4.x 回退路径 ephemeral WebContext、301 与网络错误区分、NMTID 随机化。