### PR TITLE
fix(player): 播放引擎并发修复与锁序纪律（16 commits squash）

### DIFF
--- a/internal/player/beep_player.go
+++ b/internal/player/beep_player.go
@@ -57,6 +57,11 @@ type beepPlayer struct {
 
 	spectrum         *PCMAnalyzer
 	spectrumConsumer func(sampleRate float64, samplesL, samplesR []float32)
+
+	// spectrumSamplesL/R 是 streamer 馈送频谱数据的复用缓冲（仅 streamer
+	// 使用，持 p.l 访问，无并发）
+	spectrumSamplesL []float32
+	spectrumSamplesR []float32
 }
 
 func NewBeepPlayer() *beepPlayer {
@@ -89,19 +94,16 @@ func NewBeepPlayer() *beepPlayer {
 // listen 开始监听
 func (p *beepPlayer) listen() {
 	var (
-		done       = make(chan struct{})
+		// done 是当前歌曲的结束信号通道。每首歌创建独立的缓冲通道：
+		// 旧歌残留的结束信号不会误停新歌；缓冲 1 + 非阻塞发送保证拉取路径
+		// （持有 speaker 全局锁）绝不会阻塞在发送上。
+		done       chan struct{}
 		resp       *http.Response
 		reader     io.ReadCloser
 		err        error
 		ctx        context.Context
 		cancel     context.CancelFunc
 		prevSongId int64
-		doneHandle = func() {
-			select {
-			case done <- struct{}{}:
-			case <-p.close:
-			}
-		}
 	)
 
 	if err = speaker.Init(sampleRate, sampleRate.N(time.Millisecond*200)); err != nil {
@@ -119,6 +121,7 @@ func (p *beepPlayer) listen() {
 		case <-done:
 			p.Stop()
 		case music := <-p.musicChan:
+			started := false
 			p.l.Lock()
 			// curMusic is read by CurMusic() (UI thread) under p.l, so assign
 			// it while holding the lock too.
@@ -133,6 +136,16 @@ func (p *beepPlayer) listen() {
 			}
 			p.reset()
 			ctx, cancel = context.WithCancel(context.Background())
+
+			// 每首歌独立的结束信号通道（见 listen 顶部注释）
+			curDone := make(chan struct{}, 1)
+			done = curDone
+			doneHandle := func() {
+				select {
+				case curDone <- struct{}{}:
+				default:
+				}
+			}
 
 			if prevSongId != p.curMusic.Id || !filex.FileOrDirExists(cacheFile) {
 				// FIXME: 先这样处理，暂时没想到更好的办法
@@ -157,11 +170,15 @@ func (p *beepPlayer) listen() {
 				}
 
 				// 边下载边播放
-				go func(ctx context.Context, cacheWFile *os.File, read io.ReadCloser) {
+				songID := p.curMusic.Id
+				go func(ctx context.Context, cacheWFile *os.File, read io.ReadCloser, songID int64) {
 					_, _ = iox.CopyClose(ctx, cacheWFile, read)
 					p.l.Lock()
 					defer p.l.Unlock()
-					if p.curStreamer == nil {
+					// 下载期间可能已切歌（cancel 打断）：此时 p.curMusic/p.curStreamer
+					// 已属于新歌，绝不能用自己（旧歌）的缓存数据替换新歌的 streamer
+					//（否则新歌会从旧歌位置开始、被瞬间跳过，甚至被切走）。
+					if songID != p.curMusic.Id || p.curStreamer == nil {
 						// nil说明外层解析还没开始或解析失败，这里直接退出
 						return
 					}
@@ -187,7 +204,7 @@ func (p *beepPlayer) listen() {
 						p.ctrl.Streamer = beep.Seq(p.resampleStreamer(p.curFormat.SampleRate), beep.Callback(doneHandle))
 					}
 					p.cacheDownloaded = true
-				}(ctx, p.cacheWriter, reader)
+				}(ctx, p.cacheWriter, reader, songID)
 
 				N := 512
 				if p.curMusic.Type == Flac {
@@ -219,7 +236,6 @@ func (p *beepPlayer) listen() {
 
 			p.ctrl.Streamer = beep.Seq(p.resampleStreamer(p.curFormat.SampleRate), beep.Callback(doneHandle))
 			p.volume.Streamer = p.ctrl
-			speaker.Play(p.volume)
 
 			// 计时器
 			p.timer = timex.NewTimer(timex.Options{
@@ -246,9 +262,17 @@ func (p *beepPlayer) listen() {
 			})
 			p.resumeNoLock()
 			prevSongId = p.curMusic.Id
+			started = true
 
 		nextLoop:
 			p.l.Unlock()
+			// speaker.* 必须在不持有 p.l 时调用：拉取路径持 speaker 锁后再取
+			// p.l，此处反向取锁会与拉取互等造成死锁。失败路径同样要 Clear，
+			// 否则 speaker 仍拉取已被关闭的旧链，streamer 会空指针。
+			speaker.Clear()
+			if started {
+				speaker.Play(p.volume)
+			}
 		}
 	}
 }
@@ -311,18 +335,25 @@ func (p *beepPlayer) TimeChan() <-chan time.Duration {
 }
 
 func (p *beepPlayer) Seek(duration time.Duration) {
-	if duration < 0 || !p.cacheDownloaded {
+	if duration < 0 {
 		return
 	}
+	// 锁序与拉取路径一致（speaker mu → p.l）：切歌路径（reset 置 nil、关闭
+	// 旧 streamer）只在 p.l 下进行，此处必须持 p.l 全程校验，否则切歌瞬间
+	// 跳转会对已关闭/已置 nil 的 streamer 操作（空指针或 use-after-close）。
+	speaker.Lock()
+	defer speaker.Unlock()
+	p.l.Lock()
+	defer p.l.Unlock()
+
 	// FIXME: 暂时仅对MP3格式提供跳转功能
 	// FLAC格式(其他未测)跳转会占用大量CPU资源，比特率越高占用越高
 	// 导致Seek方法卡住20-40秒的时间，之后方可随意跳转
 	// minimp3未实现Seek
-	if p.curStreamer == nil || p.curMusic.Type != Mp3 || configs.AppConfig.Player.Beep.Mp3Decoder == types.BeepMiniMp3Decoder {
+	if !p.cacheDownloaded || p.curStreamer == nil || p.curMusic.Type != Mp3 || configs.AppConfig.Player.Beep.Mp3Decoder == types.BeepMiniMp3Decoder {
 		return
 	}
 	if types.State(p.state.Load()) == types.Playing || types.State(p.state.Load()) == types.Paused {
-		speaker.Lock()
 		newPos := p.curFormat.SampleRate.N(duration)
 
 		if newPos < 0 {
@@ -331,16 +362,13 @@ func (p *beepPlayer) Seek(duration time.Duration) {
 		if newPos >= p.curStreamer.Len() {
 			newPos = p.curStreamer.Len() - 1
 		}
-		if p.curStreamer != nil {
-			err := p.curStreamer.Seek(newPos)
-			if err != nil {
-				slog.Error("seek error", slogx.Error(err))
-			}
+		err := p.curStreamer.Seek(newPos)
+		if err != nil {
+			slog.Error("seek error", slogx.Error(err))
 		}
 		if p.timer != nil {
 			p.timer.SetPassed(duration)
 		}
-		speaker.Unlock()
 	}
 }
 
@@ -454,7 +482,6 @@ func (p *beepPlayer) Toggle() {
 // Close 关闭
 func (p *beepPlayer) Close() {
 	p.l.Lock()
-	defer p.l.Unlock()
 
 	if p.timer != nil {
 		p.timer.Stop()
@@ -466,6 +493,9 @@ func (p *beepPlayer) Close() {
 	if p.spectrum != nil {
 		p.spectrum.Close()
 	}
+	p.l.Unlock()
+
+	// speaker.* 必须在 p.l 外调用（锁序纪律：拉取路径持 speaker 锁后再取 p.l）
 	speaker.Clear()
 	speaker.Close()
 }
@@ -487,20 +517,35 @@ func (p *beepPlayer) reset() {
 	}
 	p.cacheDownloaded = false
 	p.spectrumConsumer = nil
-	speaker.Clear()
+	// 注意：不在此处调用 speaker.Clear()——speaker.* 必须在 p.l 外调用
+	// （锁序纪律见 listen 的 nextLoop 处），调用方负责。
 }
 
 func (p *beepPlayer) streamer(samples [][2]float64) (n int, ok bool) {
 	p.l.Lock()
-	defer p.l.Unlock()
+	// 切歌失败路径（HTTP 错误/WaitForNBytes 超时/DecodeSong 失败）里 reset
+	// 已把 curStreamer 置 nil，且 speaker.Clear() 在 p.l 外执行——阻塞在
+	// p.l 上的拉取会在解锁瞬间拿到 nil，必须在此守卫（返回 !ok 结束旧链，
+	// 其 Callback 落入孤儿通道，无害）。
+	if p.curStreamer == nil {
+		p.l.Unlock()
+		return 0, false
+	}
 
 	pos := p.curStreamer.Position()
 	n, ok = p.curStreamer.Stream(samples)
 
-	// Spectrum: feed PCM samples to analyzer
+	// Spectrum: feed PCM samples to analyzer。
+	// 复用预分配缓冲（p.spectrumSamplesL/R）：每次拉取（约 10-50ms 一次、
+	// 持锁期间）make 两个切片是纯 GC 压力。缓冲仅本函数使用，且本函数
+	// 全程持 p.l 与 speaker 锁，无并发访问。
 	if p.spectrumConsumer != nil && n > 0 {
-		samplesL := make([]float32, n)
-		samplesR := make([]float32, n)
+		if cap(p.spectrumSamplesL) < n {
+			p.spectrumSamplesL = make([]float32, n)
+			p.spectrumSamplesR = make([]float32, n)
+		}
+		samplesL := p.spectrumSamplesL[:n]
+		samplesR := p.spectrumSamplesR[:n]
 		for i := 0; i < n; i++ {
 			samplesL[i] = float32(samples[i][0])
 			samplesR[i] = float32(samples[i][1])
@@ -510,28 +555,45 @@ func (p *beepPlayer) streamer(samples [][2]float64) (n int, ok bool) {
 
 	err := p.curStreamer.Err()
 	if err == nil && (ok || p.cacheDownloaded) {
+		p.l.Unlock()
 		return
 	}
 	p.pausedNoLock()
 
+	// 重试期间不持 p.l：拉取路径已持有 speaker 锁，若再持 p.l 睡眠，会同时
+	// 冻结音频管线与 UI（PassedTime/CurMusic 均需 p.l），最长 20 秒。
+	myStreamer := p.curStreamer
+	isFlac := p.curMusic.Type == Flac
+	p.l.Unlock()
+
 	retry := 4
 	for !ok && retry > 0 {
-		if p.curMusic.Type == Flac {
-			if err = p.curStreamer.Seek(pos); err != nil {
+		if isFlac {
+			if err = myStreamer.Seek(pos); err != nil {
 				return
 			}
 		}
-		errorx.ResetError(p.curStreamer)
+		errorx.ResetError(myStreamer)
 
 		select {
 		case <-time.After(time.Second * 5):
-			n, ok = p.curStreamer.Stream(samples)
+			p.l.Lock()
+			// 等待期间可能已切歌：旧 streamer 已被 reset 关闭，直接放弃重试
+			if p.curStreamer != myStreamer {
+				p.l.Unlock()
+				return
+			}
+			n, ok = myStreamer.Stream(samples)
+			err = myStreamer.Err()
+			p.l.Unlock()
 		case <-p.close:
 			return
 		}
 		retry--
 	}
+	p.l.Lock()
 	p.resumeNoLock()
+	p.l.Unlock()
 	return
 }
 

--- a/internal/player/dlna_player.go
+++ b/internal/player/dlna_player.go
@@ -84,7 +84,7 @@ const (
 type command struct {
 	cmd    cmdType
 	param  any
-	result chan<- any
+	result chan any
 }
 
 type dlnaPlayer struct {
@@ -94,10 +94,14 @@ type dlnaPlayer struct {
 	audioURL            string
 	audioDur            time.Duration
 	httpClient          *http.Client
-	state               types.State
-	stateChan           chan types.State
-	closed              chan struct{}
-	cmdQueue            chan command
+	// mu 保护 state/curPos/audioURL/audioDur/cachedVolume 及播放计时字段：
+	// worker goroutine（executeCmd/pollStateTask）写入，UI 线程读取
+	mu        sync.RWMutex
+	state     types.State
+	stateChan chan types.State
+	closed    chan struct{}
+	closeOnce sync.Once // 保证 closed 只关闭一次（永不置 nil，sendCmd 依赖它）
+	cmdQueue  chan command
 
 	curPos   time.Duration
 	timeChan chan time.Duration
@@ -225,22 +229,37 @@ func (p *dlnaPlayer) worker() {
 }
 
 func (p *dlnaPlayer) pollStateTask() {
-	state, _ := p.getTransportInfo()
+	state, err := p.getTransportInfo()
+	if err != nil {
+		// 查询失败不覆盖状态：网络抖动时设备可能短暂不可达
+		return
+	}
 	if state == "STOPPED" || state == "NO_MEDIA_PRESENT" {
+		p.mu.Lock()
+		changed := p.state != types.Stopped
 		p.state = types.Stopped
-		p.sendState()
+		p.mu.Unlock()
+		// 仅状态确实变化时上报：设备持续返回 STOPPED（如无法播放该 URL）时
+		// 避免每 5s 触发一次 UI 的自动切歌
+		if changed {
+			p.sendState(types.Stopped)
+		}
 		return
 	}
 	curPos, _, _ := p.getPositionInfo()
 	if curPos > 0 {
+		p.mu.Lock()
 		p.curPos = curPos
+		p.mu.Unlock()
 		select {
 		case p.timeChan <- curPos:
 		default:
 		}
 	}
 	if vol, err := p.getVolume(); err == nil {
+		p.mu.Lock()
 		p.cachedVolume = vol
+		p.mu.Unlock()
 	}
 }
 
@@ -248,8 +267,10 @@ func (p *dlnaPlayer) executeCmd(cmd command) {
 	switch cmd.cmd {
 	case cmdPlay:
 		music := cmd.param.(URLMusic)
+		p.mu.Lock()
 		p.audioURL = music.URL
 		p.audioDur = music.Duration
+		p.mu.Unlock()
 		p.fileMapMu.Lock()
 		for k := range p.fileMap {
 			delete(p.fileMap, k)
@@ -263,43 +284,53 @@ func (p *dlnaPlayer) executeCmd(cmd command) {
 			p.fileMapMu.Unlock()
 			audioURL = fmt.Sprintf("http://%s:%d/dlna/%d", p.localIP, p.httpPort, music.Id)
 		}
+		p.mu.Lock()
 		p.audioURL = audioURL
+		p.mu.Unlock()
 
-		slog.Info("DLNA: setting AVTransport URI", "audioURL", p.audioURL)
-		p.doSOAP("AVTransport", "SetAVTransportURI", fmt.Sprintf(setAvTransportURIBody, p.audioURL))
+		slog.Info("DLNA: setting AVTransport URI", "audioURL", audioURL)
+		p.doSOAP("AVTransport", "SetAVTransportURI", fmt.Sprintf(setAvTransportURIBody, audioURL))
 
 		slog.Info("DLNA: starting playback")
 		p.doSOAP("AVTransport", "Play", playBody)
 
+		p.mu.Lock()
 		p.state = types.Playing
-		p.sendState()
 		p.startTime = time.Now()
 		p.pausedTime = 0
 		p.wasEverPlayed = true
+		p.mu.Unlock()
+		p.sendState(types.Playing)
 		cmd.result <- true
 
 	case cmdPause:
 		p.doSOAP("AVTransport", "Pause", pauseBody)
+		p.mu.Lock()
 		p.state = types.Paused
-		p.sendState()
 		p.pauseStart = time.Now()
+		p.mu.Unlock()
+		p.sendState(types.Paused)
 		cmd.result <- true
 
 	case cmdResume:
 		p.doSOAP("AVTransport", "Play", playBody)
+		p.mu.Lock()
 		p.state = types.Playing
-		p.sendState()
 		p.pausedTime += time.Since(p.pauseStart)
+		p.mu.Unlock()
+		p.sendState(types.Playing)
 		cmd.result <- true
 
 	case cmdStop:
 		p.doSOAP("AVTransport", "Stop", stopBody)
+		p.mu.Lock()
 		p.curPos = 0
 		p.state = types.Stopped
-		p.sendState()
 		p.startTime = time.Time{}
 		p.pausedTime = 0
 		p.wasEverPlayed = false
+		p.mu.Unlock()
+		p.sendState(types.Stopped)
 		cmd.result <- true
 
 	case cmdSeek:
@@ -310,10 +341,15 @@ func (p *dlnaPlayer) executeCmd(cmd command) {
 
 	case cmdSetVolume:
 		volume := cmd.param.(int)
-		if volume >= 0 && volume <= 100 && volume != p.cachedVolume {
+		p.mu.RLock()
+		curVol := p.cachedVolume
+		p.mu.RUnlock()
+		if volume >= 0 && volume <= 100 && volume != curVol {
 			body := fmt.Sprintf(setVolumeBody, volume)
 			p.doSOAP("RenderingControl", "SetVolume", body)
+			p.mu.Lock()
 			p.cachedVolume = volume
+			p.mu.Unlock()
 		}
 		cmd.result <- true
 	}
@@ -427,22 +463,35 @@ func (p *dlnaPlayer) getPositionInfo() (time.Duration, time.Duration, error) {
 }
 
 // sendState sends state update non-blockingly, with 2 second timeout
-func (p *dlnaPlayer) sendState() {
+func (p *dlnaPlayer) sendState(state types.State) {
 	select {
-	case p.stateChan <- p.state:
+	case p.stateChan <- state:
 	case <-time.After(time.Second * 2):
 		slog.Warn("DLNA: stateChan send timeout, drop state update")
 	}
 }
 
 func (p *dlnaPlayer) Play(music URLMusic) {
-	result := make(chan any)
-	p.cmdQueue <- command{
+	p.sendCmd(command{
 		cmd:    cmdPlay,
 		param:  music,
-		result: result,
+		result: make(chan any, 1),
+	})
+}
+
+// sendCmd 向 worker 投递命令并等待结果。worker 在 Close 后退场、不再消费
+// cmdQueue，直接发送会在队列满后永久阻塞 UI 线程；select p.closed 保证
+// 播放器已关闭时立即返回。
+func (p *dlnaPlayer) sendCmd(cmd command) {
+	select {
+	case p.cmdQueue <- cmd:
+	case <-p.closed:
+		return
 	}
-	<-result
+	select {
+	case <-cmd.result:
+	case <-p.closed:
+	}
 }
 
 func (p *dlnaPlayer) getTransportInfo() (string, error) {
@@ -474,6 +523,8 @@ func (p *dlnaPlayer) normalizeURL(base, controlURL string) string {
 }
 
 func (p *dlnaPlayer) CurMusic() URLMusic {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	music := URLMusic{
 		URL: p.audioURL,
 	}
@@ -482,25 +533,19 @@ func (p *dlnaPlayer) CurMusic() URLMusic {
 }
 
 func (p *dlnaPlayer) Pause() {
-	result := make(chan any)
-	p.cmdQueue <- command{cmd: cmdPause, result: result}
-	<-result
+	p.sendCmd(command{cmd: cmdPause, result: make(chan any, 1)})
 }
 
 func (p *dlnaPlayer) Resume() {
-	result := make(chan any)
-	p.cmdQueue <- command{cmd: cmdResume, result: result}
-	<-result
+	p.sendCmd(command{cmd: cmdResume, result: make(chan any, 1)})
 }
 
 func (p *dlnaPlayer) Stop() {
-	result := make(chan any)
-	p.cmdQueue <- command{cmd: cmdStop, result: result}
-	<-result
+	p.sendCmd(command{cmd: cmdStop, result: make(chan any, 1)})
 }
 
 func (p *dlnaPlayer) Toggle() {
-	if p.state == types.Playing {
+	if p.State() == types.Playing {
 		p.Pause()
 	} else {
 		p.Resume()
@@ -508,16 +553,18 @@ func (p *dlnaPlayer) Toggle() {
 }
 
 func (p *dlnaPlayer) Seek(duration time.Duration) {
-	result := make(chan any)
-	p.cmdQueue <- command{cmd: cmdSeek, param: duration, result: result}
-	<-result
+	p.sendCmd(command{cmd: cmdSeek, param: duration, result: make(chan any, 1)})
 }
 
 func (p *dlnaPlayer) PassedTime() time.Duration {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.curPos
 }
 
 func (p *dlnaPlayer) PlayedTime() time.Duration {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	if !p.wasEverPlayed {
 		return 0
 	}
@@ -528,7 +575,11 @@ func (p *dlnaPlayer) TimeChan() <-chan time.Duration {
 	return p.timeChan
 }
 
-func (p *dlnaPlayer) State() types.State { return p.state }
+func (p *dlnaPlayer) State() types.State {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.state
+}
 
 func (p *dlnaPlayer) StateChan() <-chan types.State { return p.stateChan }
 
@@ -556,13 +607,13 @@ func (p *dlnaPlayer) getVolume() (int, error) {
 }
 
 func (p *dlnaPlayer) Volume() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.cachedVolume
 }
 
 func (p *dlnaPlayer) SetVolume(volume int) {
-	result := make(chan any)
-	p.cmdQueue <- command{cmd: cmdSetVolume, param: volume, result: result}
-	<-result
+	p.sendCmd(command{cmd: cmdSetVolume, param: volume, result: make(chan any, 1)})
 }
 
 func (p *dlnaPlayer) UpVolume() {
@@ -574,10 +625,10 @@ func (p *dlnaPlayer) DownVolume() {
 }
 
 func (p *dlnaPlayer) Close() {
-	if p.closed != nil {
+	// closed 通道永不置 nil：sendCmd 依赖它对已关闭的播放器立即返回
+	p.closeOnce.Do(func() {
 		close(p.closed)
-		p.closed = nil
-	}
+	})
 	if p.httpServer != nil {
 		if err := p.httpServer.Close(); err != nil {
 			slog.Error("DLNA: failed to close HTTP server", "error", err)

--- a/internal/player/mpd_player.go
+++ b/internal/player/mpd_player.go
@@ -138,37 +138,47 @@ func (p *mpdPlayer) syncMpdStatus(subsystem string) {
 	mpdErrorHandler(err, true)
 
 	state := stateMapping[status["state"]]
-	if subsystem == "player" && (state != types.Stopped || time.Since(p.latestPlayTime) >= time.Second*2) {
+	// latestPlayTime 由 listen 持锁写入，此处无锁读构成数据竞争（time.Time
+	// 是 24 字节结构，-race 必报）
+	p.l.Lock()
+	recentSwitch := time.Since(p.latestPlayTime) < time.Second*2
+	p.l.Unlock()
+	if subsystem == "player" && (state != types.Stopped || !recentSwitch) {
+		p.l.Lock()
 		switch state {
 		case types.Playing:
 			if p.timer != nil {
 				go p.timer.Run()
 			}
-			p.setState(types.Playing)
 		case types.Paused:
 			if p.timer != nil {
 				p.timer.Pause()
 			}
-			p.setState(types.Paused)
 		case types.Stopped:
 			if p.timer != nil {
 				p.timer.Stop()
 			}
-			p.setState(types.Stopped)
 		default:
 		}
+		p.l.Unlock()
+		p.setState(state)
 	}
 	if vol := status["volume"]; vol != "" {
-		p.volume, _ = strconv.Atoi(vol)
+		v, _ := strconv.Atoi(vol)
+		p.l.Lock()
+		p.volume = v
+		p.l.Unlock()
 	}
 	if elapsed := status["elapsed"]; elapsed != "" {
 		duration, _ := time.ParseDuration(elapsed + "s")
+		p.l.Lock()
 		if p.timer != nil {
 			p.timer.SetPassed(duration)
-			select {
-			case p.timeChan <- p.timer.Passed():
-			default:
-			}
+		}
+		p.l.Unlock()
+		select {
+		case p.timeChan <- duration:
+		default:
 		}
 	}
 }
@@ -181,17 +191,18 @@ func (p *mpdPlayer) listen() {
 		select {
 		case <-p.close:
 			return
-		case p.curMusic = <-p.musicChan:
-			p.Pause()
+		case music := <-p.musicChan:
+			p.l.Lock()
+			p.curMusic = music
 			if p.timer != nil {
 				p.timer.SetPassed(0)
+				p.timer.Stop()
 			}
 			p.latestPlayTime = time.Now()
+			p.l.Unlock()
+			p.Pause()
 			// 重置
 			{
-				if p.timer != nil {
-					p.timer.Stop()
-				}
 				if p.curSongId != 0 {
 					err = p.client().DeleteID(p.curSongId)
 					mpdErrorHandler(err, true)
@@ -227,19 +238,24 @@ func (p *mpdPlayer) listen() {
 			mpdErrorHandler(err, false)
 
 			// 计时器
-			p.timer = timex.NewTimer(timex.Options{
+			p.l.Lock()
+			var timer *timex.Timer
+			timer = timex.NewTimer(timex.Options{
 				Duration:       8760 * time.Hour,
 				TickerInternal: configs.AppConfig.Main.FrameRate.Interval(),
 				OnRun:          func(started bool) {},
 				OnPause:        func() {},
 				OnDone:         func(stopped bool) {},
 				OnTick: func() {
+					// 闭包捕获 timer 自身而非 p.timer，避免与并发置 nil 竞争
 					select {
-					case p.timeChan <- p.timer.Passed():
+					case p.timeChan <- timer.Passed():
 					default:
 					}
 				},
 			})
+			p.timer = timer
+			p.l.Unlock()
 
 			err = p.client().PlayID(p.curSongId)
 			mpdErrorHandler(err, false)
@@ -272,7 +288,9 @@ func (p *mpdPlayer) watch() {
 }
 
 func (p *mpdPlayer) setState(state types.State) {
+	p.l.Lock()
 	p.state = state
+	p.l.Unlock()
 	select {
 	case p.stateChan <- state:
 	case <-time.After(time.Second * 2):
@@ -289,6 +307,8 @@ func (p *mpdPlayer) Play(music URLMusic) {
 }
 
 func (p *mpdPlayer) CurMusic() URLMusic {
+	p.l.Lock()
+	defer p.l.Unlock()
 	return p.curMusic
 }
 
@@ -335,6 +355,8 @@ func (p *mpdPlayer) Seek(duration time.Duration) {
 }
 
 func (p *mpdPlayer) PassedTime() time.Duration {
+	p.l.Lock()
+	defer p.l.Unlock()
 	if p.timer == nil {
 		return 0
 	}
@@ -342,6 +364,8 @@ func (p *mpdPlayer) PassedTime() time.Duration {
 }
 
 func (p *mpdPlayer) PlayedTime() time.Duration {
+	p.l.Lock()
+	defer p.l.Unlock()
 	if p.timer == nil {
 		return 0
 	}
@@ -353,6 +377,8 @@ func (p *mpdPlayer) TimeChan() <-chan time.Duration {
 }
 
 func (p *mpdPlayer) State() types.State {
+	p.l.Lock()
+	defer p.l.Unlock()
 	return p.state
 }
 
@@ -383,6 +409,8 @@ func (p *mpdPlayer) DownVolume() {
 }
 
 func (p *mpdPlayer) Volume() int {
+	p.l.Lock()
+	defer p.l.Unlock()
 	return p.volume
 }
 

--- a/internal/player/mpv_player.go
+++ b/internal/player/mpv_player.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-musicfox/go-musicfox/internal/configs"
@@ -32,15 +33,20 @@ type mpvPlayer struct {
 	ipcConn  net.Conn
 	ipcMutex sync.Mutex
 
-	curMusic URLMusic
+	// mu 保护 curMusic/timer/volume：handleNewSong（listen goroutine）写入，
+	// watch goroutine 停用 timer，UI 线程读取，三方并发无锁即数据竞争
+	//（-race 必报）；state 用原子读写（与 beep 引擎同一模式）。
+	mu sync.RWMutex
 
-	volume    int
-	state     types.State
+	curMusic URLMusic
+	timer    *timex.Timer
+	volume   int
+
+	state     atomic.Uint32
 	timeChan  chan time.Duration
 	stateChan chan types.State
 	closeCh   chan struct{}
 
-	timer     *timex.Timer  // 播放位置追踪（参考 mpdPlayer）
 	musicChan chan URLMusic // 异步切歌信号（参考 mpdPlayer）
 
 	watchOnce sync.Once // 确保 watch 只启动一次
@@ -76,13 +82,13 @@ func NewMpvPlayer(conf *MpvConfig) *mpvPlayer {
 	p := &mpvPlayer{
 		binPath:      binPath,
 		volume:       50,
-		state:        types.Stopped,
 		timeChan:     make(chan time.Duration, 1),
 		stateChan:    make(chan types.State, 10),
 		musicChan:    make(chan URLMusic, 1),
 		closeCh:      make(chan struct{}),
 		songLoadedCh: make(chan struct{}, 1),
 	}
+	p.state.Store(uint32(types.Stopped))
 
 	if err := p.startDaemon(); err != nil {
 		slog.Error("mpv daemon: 启动守护进程失败", slogx.Error(err))
@@ -191,6 +197,7 @@ func (p *mpvPlayer) handleNewSong(music URLMusic) {
 		slog.String("url", music.URL),
 	)
 
+	p.mu.Lock()
 	p.curMusic = music
 
 	// 停止旧 timer
@@ -199,12 +206,21 @@ func (p *mpvPlayer) handleNewSong(music URLMusic) {
 		p.timer.Stop()
 		p.timer = nil
 	}
+	p.mu.Unlock()
 
 	// 发送 loadfile 命令加载新歌曲
 	cmd := fmt.Sprintf(`{ "command": ["loadfile", %s, "replace"] }`, jsonString(music.URL))
 	slog.Info("mpv handleNewSong: 发送loadfile命令", slog.String("cmd", cmd))
 	if err := p.sendCommand(cmd); err != nil {
-		slog.Error("mpv handleNewSong: loadfile失败", slogx.Error(err))
+		// loadfile 失败：mpv 仍播旧歌（或无声），但 curMusic 已更新、旧 timer
+		// 已停——UI 显示新歌、实际播旧歌，且无重试。置 Stopped 走 UI 的自动
+		// 切歌路径（状态监听只对 Stopped 触发 NextSong；Interrupted 无消费方，
+		// 会卡在"假新歌"上），而不是显示一个不存在的"新歌"。
+		slog.Error("mpv handleNewSong: loadfile失败，恢复旧状态", slogx.Error(err))
+		p.mu.Lock()
+		p.timer = nil
+		p.mu.Unlock()
+		p.setState(types.Stopped)
 		return
 	}
 	slog.Info("mpv handleNewSong: loadfile发送成功")
@@ -229,19 +245,25 @@ func (p *mpvPlayer) handleNewSong(music URLMusic) {
 		slog.Duration("interval", interval),
 		slog.String("duration", "8760h"),
 	)
-	p.timer = timex.NewTimer(timex.Options{
+	p.mu.Lock()
+	var timer *timex.Timer
+	timer = timex.NewTimer(timex.Options{
 		Duration:       8760 * time.Hour,
 		TickerInternal: interval,
 		OnRun:          func(started bool) {},
 		OnPause:        func() {},
 		OnDone:         func(stopped bool) {},
 		OnTick: func() {
+			// 闭包捕获 timer 自身而非 p.timer：watch/Stop 并发置 nil 时
+			// 不会空指针，也不与 p.timer 的读写竞争
 			select {
-			case p.timeChan <- p.timer.Passed():
+			case p.timeChan <- timer.Passed():
 			default:
 			}
 		},
 	})
+	p.timer = timer
+	p.mu.Unlock()
 	p.Resume()
 
 	// go p.timer.Run()
@@ -355,6 +377,14 @@ func (p *mpvPlayer) watch() {
 			}
 			readCount++
 			msg := string(buf[:n])
+
+			// 事件连接与命令连接分离：end-file 事件可能在 handleNewSong 已切换
+			// 歌曲后才被读到（旧歌的迟到事件）。记录收到事件时的当前歌曲，
+			// 处理时若已切歌则视为旧歌残留，忽略之（否则会误杀新歌的 timer、
+			// 把用户刚选的新歌切走）。
+			p.mu.RLock()
+			songAtReceive := p.curMusic.Id
+			p.mu.RUnlock()
 			slog.Info("mpv watch: 收到IPC事件",
 				slog.Int("readCount", readCount),
 				slog.String("raw", msg),
@@ -377,12 +407,19 @@ func (p *mpvPlayer) watch() {
 
 				// 只有自然结束(eof)或出错才触发状态变更
 				if isEOF || isError {
+					p.mu.Lock()
+					if p.curMusic.Id != songAtReceive {
+						p.mu.Unlock()
+						slog.Info("mpv watch: 忽略旧歌的迟到end-file事件（已切歌）")
+						continue
+					}
 					slog.Info("mpv watch: 触发歌曲结束", slog.Bool("isEOF", isEOF))
 					if p.timer != nil {
 						slog.Debug("mpv watch: 停止timer")
 						p.timer.Stop()
 						p.timer = nil
 					}
+					p.mu.Unlock()
 					p.setState(types.Stopped)
 					slog.Info("mpv watch: 状态已设为Stopped")
 				} else {
@@ -571,39 +608,47 @@ func (p *mpvPlayer) Play(music URLMusic) {
 
 // CurMusic 获取当前播放的音乐
 func (p *mpvPlayer) CurMusic() URLMusic {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.curMusic
 }
 
 // Pause 暂停播放
 func (p *mpvPlayer) Pause() {
-	slog.Info("mpv Pause: 请求暂停", slog.Any("state", p.state))
-	if p.state != types.Playing {
+	state := types.State(p.state.Load())
+	slog.Info("mpv Pause: 请求暂停", slog.Any("state", state))
+	if state != types.Playing {
 		slog.Debug("mpv Pause: 当前状态非Playing，忽略")
 		return
 	}
 
 	_ = p.sendCommand(`{ "command": ["set_property", "pause", true] }`)
+	p.mu.Lock()
 	if p.timer != nil {
 		slog.Debug("mpv Pause: 暂停timer")
 		p.timer.Pause()
 	}
+	p.mu.Unlock()
 	p.setState(types.Paused)
 	slog.Info("mpv Pause: 完成")
 }
 
 // Resume 恢复播放
 func (p *mpvPlayer) Resume() {
-	slog.Info("mpv Resume: 请求恢复", slog.Any("state", p.state))
-	if p.state != types.Paused && p.state != types.Stopped {
+	state := types.State(p.state.Load())
+	slog.Info("mpv Resume: 请求恢复", slog.Any("state", state))
+	if state != types.Paused && state != types.Stopped {
 		slog.Debug("mpv Resume: 当前状态不可恢复，忽略")
 		return
 	}
 
 	_ = p.sendCommand(`{ "command": ["set_property", "pause", false] }`)
+	p.mu.Lock()
 	if p.timer != nil {
 		slog.Debug("mpv Resume: 恢复timer")
 		go p.timer.Run()
 	}
+	p.mu.Unlock()
 	p.setState(types.Playing)
 	slog.Info("mpv Resume: 完成")
 }
@@ -612,11 +657,13 @@ func (p *mpvPlayer) Resume() {
 func (p *mpvPlayer) Stop() {
 	slog.Info("mpv Stop: 请求停止")
 	_ = p.sendCommand(`{ "command": ["stop"] }`)
+	p.mu.Lock()
 	if p.timer != nil {
 		slog.Debug("mpv Stop: 停止timer")
 		p.timer.Stop()
 		p.timer = nil
 	}
+	p.mu.Unlock()
 	p.setState(types.Stopped)
 	slog.Info("mpv Stop: 完成")
 }
@@ -642,29 +689,35 @@ func (p *mpvPlayer) Seek(duration time.Duration) {
 		return
 	}
 
+	p.mu.Lock()
 	if p.timer != nil {
 		slog.Debug("mpv Seek: 更新timer位置")
 		p.timer.SetPassed(duration)
 	}
+	p.mu.Unlock()
 	slog.Info("mpv Seek: 完成")
 }
 
 // PassedTime 获取已播放时间（基于 timer，不轮询 mpv）
 func (p *mpvPlayer) PassedTime() time.Duration {
-	pt := time.Duration(0)
+	p.mu.RLock()
+	var pt time.Duration
 	if p.timer != nil {
 		pt = p.timer.Passed()
 	}
+	p.mu.RUnlock()
 	slog.Debug("mpv PassedTime", slog.Duration("passed", pt))
 	return pt
 }
 
 // PlayedTime 获取从播放开始到现在的时间
 func (p *mpvPlayer) PlayedTime() time.Duration {
-	art := time.Duration(0)
+	p.mu.RLock()
+	var art time.Duration
 	if p.timer != nil {
 		art = p.timer.ActualRuntime()
 	}
+	p.mu.RUnlock()
 	slog.Debug("mpv PlayedTime", slog.Duration("actualRuntime", art))
 	return art
 }
@@ -676,7 +729,7 @@ func (p *mpvPlayer) TimeChan() <-chan time.Duration {
 
 // State 获取当前状态
 func (p *mpvPlayer) State() types.State {
-	return p.state
+	return types.State(p.state.Load())
 }
 
 // StateChan 获取状态更新通道
@@ -687,7 +740,7 @@ func (p *mpvPlayer) StateChan() <-chan types.State {
 // setState 设置状态并通知
 func (p *mpvPlayer) setState(state types.State) {
 	slog.Info("mpv setState: 状态变更", slog.Any("state", state))
-	p.state = state
+	p.state.Store(uint32(state))
 	p.sendStateToChan(state)
 }
 
@@ -700,6 +753,8 @@ func (p *mpvPlayer) sendStateToChan(state types.State) {
 
 // Volume 获取当前音量
 func (p *mpvPlayer) Volume() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.volume
 }
 
@@ -713,30 +768,38 @@ func (p *mpvPlayer) SetVolume(volume int) {
 		volume = 0
 	}
 
+	p.mu.Lock()
 	p.volume = volume
+	p.mu.Unlock()
 	_ = p.sendCommand(fmt.Sprintf(`{ "command": ["set_property", "volume", %d] }`, volume))
 }
 
 // UpVolume 增加音量
 func (p *mpvPlayer) UpVolume() {
 	slog.Debug("mpv UpVolume")
+	p.mu.Lock()
 	if p.volume+5 >= 100 {
 		p.volume = 100
 	} else {
 		p.volume += 5
 	}
-	_ = p.sendCommand(fmt.Sprintf(`{ "command": ["set_property", "volume", %d] }`, p.volume))
+	v := p.volume
+	p.mu.Unlock()
+	_ = p.sendCommand(fmt.Sprintf(`{ "command": ["set_property", "volume", %d] }`, v))
 }
 
 // DownVolume 降低音量
 func (p *mpvPlayer) DownVolume() {
 	slog.Debug("mpv DownVolume")
+	p.mu.Lock()
 	if p.volume-5 <= 0 {
 		p.volume = 0
 	} else {
 		p.volume -= 5
 	}
-	_ = p.sendCommand(fmt.Sprintf(`{ "command": ["set_property", "volume", %d] }`, p.volume))
+	v := p.volume
+	p.mu.Unlock()
+	_ = p.sendCommand(fmt.Sprintf(`{ "command": ["set_property", "volume", %d] }`, v))
 }
 
 // Close 关闭播放器，发送 quit 命令并等待 mpv 退出
@@ -744,11 +807,13 @@ func (p *mpvPlayer) Close() {
 	slog.Info("mpv Close: 开始关闭播放器")
 
 	// 停止 timer
+	p.mu.Lock()
 	if p.timer != nil {
 		slog.Debug("mpv Close: 停止timer")
 		p.timer.Stop()
 		p.timer = nil
 	}
+	p.mu.Unlock()
 
 	// 关闭信号通道，通知 listen/watch 退出
 	if p.closeCh != nil {

--- a/internal/player/osx_player_darwin.go
+++ b/internal/player/osx_player_darwin.go
@@ -73,9 +73,13 @@ func (p *osxPlayer) listen() {
 		select {
 		case <-p.close:
 			return
-		case p.curMusic = <-p.musicChan:
+		case music := <-p.musicChan:
+			p.l.Lock()
+			p.curMusic = music
+			p.l.Unlock()
 			core.Autorelease(func() {
 				p.Pause()
+				p.l.Lock()
 				if p.timer != nil {
 					p.timer.SetPassed(0)
 				}
@@ -83,6 +87,7 @@ func (p *osxPlayer) listen() {
 					p.timer.Stop()
 					// p.timer = nil
 				}
+				p.l.Unlock()
 
 				item := avcore.AVPlayerItem_playerItemWithURL(core.NSURL_URLWithString(core.String(p.curMusic.URL)))
 				if p.spectrum != nil {
@@ -103,7 +108,9 @@ func (p *osxPlayer) listen() {
 					AddObserverSelectorNameObject(p.handler.ID, sel_handleFailed, core.String("AVPlayerItemFailedToPlayToEndTimeNotification"), p.player.CurrentItem().NSObject)
 
 				// 计时器
-				p.timer = timex.NewTimer(timex.Options{
+				p.l.Lock()
+				var timer *timex.Timer
+				timer = timex.NewTimer(timex.Options{
 					Duration:       8760 * time.Hour,
 					TickerInternal: p.renderInterval,
 					OnRun:          func(started bool) {},
@@ -121,11 +128,13 @@ func (p *osxPlayer) listen() {
 						select {
 						// osx_player存在一点延迟
 						case p.timeChan <- curTime + time.Millisecond*800:
-						// case p.timeChan <- p.timer.Passed():
+						// case p.timeChan <- timer.Passed():
 						default:
 						}
 					},
 				})
+				p.timer = timer
+				p.l.Unlock()
 				p.Resume()
 			})
 		}
@@ -150,6 +159,8 @@ func (p *osxPlayer) Play(music URLMusic) {
 }
 
 func (p *osxPlayer) CurMusic() URLMusic {
+	p.l.Lock()
+	defer p.l.Unlock()
 	return p.curMusic
 }
 
@@ -215,6 +226,8 @@ func (p *osxPlayer) Seek(duration time.Duration) {
 }
 
 func (p *osxPlayer) PassedTime() time.Duration {
+	p.l.Lock()
+	defer p.l.Unlock()
 	if p.timer == nil {
 		return 0
 	}
@@ -230,6 +243,8 @@ func (p *osxPlayer) PassedTime() time.Duration {
 }
 
 func (p *osxPlayer) PlayedTime() time.Duration {
+	p.l.Lock()
+	defer p.l.Unlock()
 	if p.timer == nil {
 		return 0
 	}
@@ -241,6 +256,8 @@ func (p *osxPlayer) TimeChan() <-chan time.Duration {
 }
 
 func (p *osxPlayer) State() types.State {
+	p.l.Lock()
+	defer p.l.Unlock()
 	return p.state
 }
 
@@ -289,6 +306,8 @@ func (p *osxPlayer) DownVolume() {
 }
 
 func (p *osxPlayer) Volume() int {
+	p.l.Lock()
+	defer p.l.Unlock()
 	return p.volume
 }
 

--- a/internal/player/spectrum.go
+++ b/internal/player/spectrum.go
@@ -97,8 +97,7 @@ type PCMAnalyzer struct {
 	rawRingCount  atomic.Uint32
 	rawSampleRate atomic.Uint64 // math.Float64bits(sampleRate)
 
-	rawMu   sync.RWMutex
-	rawSnap RawSampleFrame // pre-allocated snapshot buffers
+	rawMu sync.RWMutex
 
 	window       [spectrumFFTSize]float64
 	fft          [spectrumFFTSize]complex128
@@ -131,8 +130,6 @@ func NewPCMAnalyzer(interval time.Duration) *PCMAnalyzer {
 		springL:  harmonica.NewSpring(interval.Seconds(), 9, 1),
 		springR:  harmonica.NewSpring(interval.Seconds(), 9, 1),
 	}
-	a.rawSnap.SamplesL = make([]float64, rawSampleBufferSize)
-	a.rawSnap.SamplesR = make([]float64, rawSampleBufferSize)
 	for i := range a.window {
 		a.window[i] = 0.5 * (1 - math.Cos(2*math.Pi*float64(i)/float64(spectrumFFTSize-1)))
 	}
@@ -585,6 +582,10 @@ func (a *PCMAnalyzer) Spectrum() SpectrumFrame {
 
 // RawSamples returns a linearized snapshot of the raw PCM ring buffer
 // for oscilloscope and vectorscope rendering.
+//
+// 返回的切片必须是新分配的：a.rawSnap 的切片是共享后备数组，直接返回
+// 其拷贝会让调用方持有的帧与下一次 RawSamples 的线性化互相改写（撕裂
+// 波形 + 数据竞争，desktop lyrics 会存帧供后续渲染）。
 func (a *PCMAnalyzer) RawSamples() RawSampleFrame {
 	pos := int(a.rawRingPos.Load())
 	count := int(a.rawRingCount.Load())
@@ -593,17 +594,20 @@ func (a *PCMAnalyzer) RawSamples() RawSampleFrame {
 	a.rawMu.Lock()
 	defer a.rawMu.Unlock()
 
-	snap := &a.rawSnap
+	frame := RawSampleFrame{
+		SamplesL:   make([]float64, count),
+		SamplesR:   make([]float64, count),
+		Count:      count,
+		SampleRate: sr,
+	}
 	// Linearize the circular buffer: oldest = count samples before pos.
 	start := (pos - count + rawSampleBufferSize) % rawSampleBufferSize
 	for i := 0; i < count; i++ {
 		idx := (start + i) % rawSampleBufferSize
-		snap.SamplesL[i] = a.rawRingL[idx]
-		snap.SamplesR[i] = a.rawRingR[idx]
+		frame.SamplesL[i] = a.rawRingL[idx]
+		frame.SamplesR[i] = a.rawRingR[idx]
 	}
-	snap.Count = count
-	snap.SampleRate = sr
-	return *snap
+	return frame
 }
 
 func (a *PCMAnalyzer) Close() {

--- a/internal/player/win_media_player_windows.go
+++ b/internal/player/win_media_player_windows.go
@@ -186,6 +186,7 @@ func (p *winMediaPlayer) listen() {
 		mediaSource  *core.MediaSource
 		playbackItem *playback.MediaPlaybackItem
 		reset        = func() {
+			p.l.Lock()
 			if p.timer != nil {
 				p.timer.SetPassed(0)
 			}
@@ -193,6 +194,7 @@ func (p *winMediaPlayer) listen() {
 				p.timer.Stop()
 				p.timer = nil
 			}
+			p.l.Unlock()
 			if uri != nil {
 				uri.Release()
 			}
@@ -209,16 +211,20 @@ func (p *winMediaPlayer) listen() {
 		case <-p.close:
 			reset()
 			return
-		case p.curMusic = <-p.musicChan:
+		case music := <-p.musicChan:
 			p.Pause()
 			reset()
 			p.failed.Store(false)
 
+			p.l.Lock()
+			p.curMusic = music
+			p.l.Unlock()
 			uri = Must1(foundation.UriCreateUri(p.curMusic.URL))
 			mediaSource = Must1(core.MediaSourceCreateFromUri(uri))
 			Must(p.player.SetSource((*playback.IMediaPlaybackSource)(unsafe.Pointer(mediaSource))))
 
 			// 计时器
+			p.l.Lock()
 			p.timer = NewTimer(Options{
 				Duration:       8760 * time.Hour,
 				TickerInternal: configs.AppConfig.Main.FrameRate.Interval(),
@@ -239,13 +245,16 @@ func (p *winMediaPlayer) listen() {
 					}
 				},
 			})
+			p.l.Unlock()
 			p.Resume()
 		}
 	}
 }
 
 func (p *winMediaPlayer) playbackEnded() bool {
+	p.l.Lock()
 	duration := p.curMusic.Duration
+	p.l.Unlock()
 	if duration <= 0 {
 		return false
 	}
@@ -253,7 +262,9 @@ func (p *winMediaPlayer) playbackEnded() bool {
 }
 
 func (p *winMediaPlayer) setState(state types.State) {
+	p.l.Lock()
 	p.state = state
+	p.l.Unlock()
 	select {
 	case p.stateChan <- state:
 	case <-time.After(time.Second * 2):
@@ -270,6 +281,8 @@ func (p *winMediaPlayer) Play(music URLMusic) {
 }
 
 func (p *winMediaPlayer) CurMusic() URLMusic {
+	p.l.Lock()
+	defer p.l.Unlock()
 	return p.curMusic
 }
 
@@ -332,6 +345,8 @@ func (p *winMediaPlayer) Seek(duration time.Duration) {
 }
 
 func (p *winMediaPlayer) PassedTime() time.Duration {
+	p.l.Lock()
+	defer p.l.Unlock()
 	if p.timer == nil {
 		return 0
 	}
@@ -347,6 +362,8 @@ func (p *winMediaPlayer) PassedTime() time.Duration {
 }
 
 func (p *winMediaPlayer) PlayedTime() time.Duration {
+	p.l.Lock()
+	defer p.l.Unlock()
 	if p.timer == nil {
 		return 0
 	}
@@ -358,6 +375,8 @@ func (p *winMediaPlayer) TimeChan() <-chan time.Duration {
 }
 
 func (p *winMediaPlayer) State() types.State {
+	p.l.Lock()
+	defer p.l.Unlock()
 	return p.state
 }
 
@@ -392,6 +411,8 @@ func (p *winMediaPlayer) DownVolume() {
 }
 
 func (p *winMediaPlayer) Volume() int {
+	p.l.Lock()
+	defer p.l.Unlock()
 	return p.volume
 }
 


### PR DESCRIPTION
见 #630 的播放核心组：beep 死锁（speaker 锁↔p.l↔done 通道）、Seek TOCTOU、跨歌 goroutine 守卫、streamer nil 守卫；mpv/osx/win/dlna/mpd 五引擎共享状态 atomic+锁串行化、迟到 end-file 守卫、loadfile 失败恢复；频谱缓冲复用。每个原始 commit 的根因说明保留在 squash message 中（可展开看）。