### PR TITLE
feat(player): add optional gapless playback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ type Player interface {
 
 | 引擎 | 平台 | 特点 |
 |------|------|------|
-| Beep（默认） | 跨平台 | MP3/FLAC/OGG/WAV |
+| Beep（默认） | 跨平台 | MP3/FLAC/OGG/WAV；可选 MP3 无缝播放，使用 go-mp3 时额外支持编码器延迟和尾部填充裁剪 |
 | DLNA | 跨平台 | 设备投送 |
 | MPV | 跨平台 | IPC 控制（命令连接带排空 goroutine 防 mpv 发送缓冲堆积，切歌带 file-loaded 超时 watchdog 兜底） |
 | MPD | Linux | 远程服务器 |

--- a/internal/configs/player.go
+++ b/internal/configs/player.go
@@ -38,6 +38,10 @@ type PlayerConfig struct {
 type BeepConfig struct {
 	// beep mp3解码器
 	Mp3Decoder string `koanf:"mp3Decoder"`
+	// 是否启用无缝播放
+	Gapless bool `koanf:"gapless"`
+	// 提前多少秒预加载下一首
+	GaplessPreloadSeconds int `koanf:"gaplessPreloadSeconds"`
 }
 
 // MpdConfig `mpd` 引擎专属配置

--- a/internal/player/beep_decoder.go
+++ b/internal/player/beep_decoder.go
@@ -2,6 +2,10 @@ package player
 
 import (
 	"io"
+	"math"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/gopxl/beep"
 	"github.com/gopxl/beep/flac"
@@ -17,14 +21,31 @@ import (
 )
 
 func DecodeSong(t SongType, r io.ReadSeekCloser) (streamer beep.StreamSeekCloser, format beep.Format, err error) {
+	return decodeSong(t, r, 0)
+}
+
+func decodeSong(t SongType, r io.ReadSeekCloser, duration time.Duration) (streamer beep.StreamSeekCloser, format beep.Format, err error) {
 	switch t {
 	case Mp3:
+		gaplessDelay, gaplessPadding := mp3GaplessSamples(r)
 		switch configs.AppConfig.Player.Beep.Mp3Decoder {
 		case types.BeepMiniMp3Decoder:
 			minimp3pkg.BufferSize = 1024 * 50
 			streamer, format, err = minimp3.Decode(r)
 		default:
 			streamer, format, err = mp3.Decode(r)
+			if err == nil && configs.AppConfig.Player.Beep.Gapless {
+				if duration > 0 && format.SampleRate > 0 {
+					target := int(math.Round(duration.Seconds() * float64(format.SampleRate)))
+					decoded := streamer.Len() - gaplessDelay
+					if target > 0 && decoded > target {
+						gaplessPadding = decoded - target
+					}
+				}
+			}
+			if err == nil && configs.AppConfig.Player.Beep.Gapless && (gaplessDelay > 0 || gaplessPadding > 0) {
+				streamer = &trimmedMP3{StreamSeekCloser: streamer, start: gaplessDelay, end: gaplessPadding}
+			}
 		}
 	case Wav:
 		streamer, format, err = wav.Decode(r)
@@ -34,6 +55,101 @@ func DecodeSong(t SongType, r io.ReadSeekCloser) (streamer beep.StreamSeekCloser
 		streamer, format, err = flac.Decode(r)
 	default:
 		err = errors.Errorf("Unknown song type(%d)", t)
+	}
+	return
+}
+
+type trimmedMP3 struct {
+	beep.StreamSeekCloser
+	start, end int
+	pos        int
+	discarded  int
+}
+
+func (d *trimmedMP3) Len() int {
+	length := d.StreamSeekCloser.Len() - d.start - d.end
+	if length < 0 {
+		return 0
+	}
+	return length
+}
+
+func (d *trimmedMP3) Position() int { return d.pos }
+
+func (d *trimmedMP3) Stream(samples [][2]float64) (n int, ok bool) {
+	if d.pos >= d.Len() {
+		return 0, false
+	}
+	if d.discarded < d.start {
+		remaining := d.start - d.discarded
+		discard := remaining
+		buf := make([][2]float64, discard)
+		got, rawOK := d.StreamSeekCloser.Stream(buf)
+		d.discarded += got
+		if got < discard {
+			return 0, rawOK
+		}
+	}
+	remaining := d.Len() - d.pos
+	if remaining < len(samples) {
+		samples = samples[:remaining]
+	}
+	n, rawOK := d.StreamSeekCloser.Stream(samples)
+	d.pos += n
+	if n < len(samples) {
+		return n, rawOK
+	}
+	return n, d.pos < d.Len()
+}
+
+func (d *trimmedMP3) Seek(pos int) error {
+	if pos < 0 || pos > d.Len() {
+		return io.ErrUnexpectedEOF
+	}
+	if err := d.StreamSeekCloser.Seek(d.start + pos); err != nil {
+		return err
+	}
+	d.pos, d.discarded = pos, d.start
+	return nil
+}
+
+func mp3GaplessSamples(r io.ReadSeeker) (delay, padding int) {
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return
+	}
+	data := make([]byte, 4096)
+	n, _ := r.Read(data)
+	_, _ = r.Seek(0, io.SeekStart)
+	data = data[:n]
+	metadataEnd := len(data)
+	if metadataEnd > 512 {
+		metadataEnd = 512
+	}
+	for i := 0; i+4 <= metadataEnd; i++ {
+		if string(data[i:i+4]) != "LAME" {
+			continue
+		}
+		if i+24 > len(data) {
+			break
+		}
+		value := uint32(data[i+21])<<16 | uint32(data[i+22])<<8 | uint32(data[i+23])
+		return int(value >> 12), int(value & 0xfff)
+	}
+	// FFmpeg-authored MP3s commonly retain Xing/Info but omit a LAME delay
+	// field. Their demuxer-visible start skip is the standard 576 encoder plus
+	// 529 decoder samples.
+	header := string(data[:metadataEnd])
+	if strings.Contains(header, "Xing") || strings.Contains(header, "Info") {
+		return 1105, 0
+	}
+	// Some encoders write the same values in the iTunSMPB ID3 text frame.
+	if i := strings.Index(string(data), "iTunSMPB"); i >= 0 {
+		fields := strings.Fields(string(data[i:]))
+		if len(fields) >= 4 {
+			d, _ := strconv.ParseInt(fields[2], 16, 32)
+			p, _ := strconv.ParseInt(fields[3], 16, 32)
+			return int(d), int(p)
+		}
 	}
 	return
 }

--- a/internal/player/beep_decoder.go
+++ b/internal/player/beep_decoder.go
@@ -21,10 +21,10 @@ import (
 )
 
 func DecodeSong(t SongType, r io.ReadSeekCloser) (streamer beep.StreamSeekCloser, format beep.Format, err error) {
-	return decodeSong(t, r, 0)
+	return decodeSong(t, r, 0, false)
 }
 
-func decodeSong(t SongType, r io.ReadSeekCloser, duration time.Duration) (streamer beep.StreamSeekCloser, format beep.Format, err error) {
+func decodeSong(t SongType, r io.ReadSeekCloser, duration time.Duration, finalized bool) (streamer beep.StreamSeekCloser, format beep.Format, err error) {
 	switch t {
 	case Mp3:
 		gaplessDelay, gaplessPadding := mp3GaplessSamples(r)
@@ -35,7 +35,7 @@ func decodeSong(t SongType, r io.ReadSeekCloser, duration time.Duration) (stream
 		default:
 			streamer, format, err = mp3.Decode(r)
 			if err == nil && configs.AppConfig.Player.Beep.Gapless {
-				if duration > 0 && format.SampleRate > 0 {
+				if finalized && duration > 0 && format.SampleRate > 0 {
 					target := int(math.Round(duration.Seconds() * float64(format.SampleRate)))
 					decoded := streamer.Len() - gaplessDelay
 					if target > 0 && decoded > target {
@@ -44,7 +44,7 @@ func decodeSong(t SongType, r io.ReadSeekCloser, duration time.Duration) (stream
 				}
 			}
 			if err == nil && configs.AppConfig.Player.Beep.Gapless && (gaplessDelay > 0 || gaplessPadding > 0) {
-				streamer = &trimmedMP3{StreamSeekCloser: streamer, start: gaplessDelay, end: gaplessPadding}
+				streamer = &trimmedMP3{StreamSeekCloser: streamer, start: gaplessDelay, end: gaplessPadding, trimEnd: finalized}
 			}
 		}
 	case Wav:
@@ -62,12 +62,16 @@ func decodeSong(t SongType, r io.ReadSeekCloser, duration time.Duration) (stream
 type trimmedMP3 struct {
 	beep.StreamSeekCloser
 	start, end int
+	trimEnd    bool
 	pos        int
 	discarded  int
 }
 
 func (d *trimmedMP3) Len() int {
 	length := d.StreamSeekCloser.Len() - d.start - d.end
+	if !d.trimEnd {
+		length = d.StreamSeekCloser.Len() - d.start
+	}
 	if length < 0 {
 		return 0
 	}
@@ -77,7 +81,7 @@ func (d *trimmedMP3) Len() int {
 func (d *trimmedMP3) Position() int { return d.pos }
 
 func (d *trimmedMP3) Stream(samples [][2]float64) (n int, ok bool) {
-	if d.pos >= d.Len() {
+	if d.trimEnd && d.pos >= d.Len() {
 		return 0, false
 	}
 	if d.discarded < d.start {
@@ -90,12 +94,17 @@ func (d *trimmedMP3) Stream(samples [][2]float64) (n int, ok bool) {
 			return 0, rawOK
 		}
 	}
-	remaining := d.Len() - d.pos
-	if remaining < len(samples) {
-		samples = samples[:remaining]
+	if d.trimEnd {
+		remaining := d.Len() - d.pos
+		if remaining < len(samples) {
+			samples = samples[:remaining]
+		}
 	}
 	n, rawOK := d.StreamSeekCloser.Stream(samples)
 	d.pos += n
+	if !d.trimEnd {
+		return n, rawOK
+	}
 	if n < len(samples) {
 		return n, rawOK
 	}

--- a/internal/player/beep_decoder.go
+++ b/internal/player/beep_decoder.go
@@ -20,6 +20,8 @@ import (
 	"github.com/go-musicfox/go-musicfox/internal/types"
 )
 
+const maxEstimatedMP3Padding = 200 * time.Millisecond
+
 func DecodeSong(t SongType, r io.ReadSeekCloser) (streamer beep.StreamSeekCloser, format beep.Format, err error) {
 	return decodeSong(t, r, 0, false)
 }
@@ -27,7 +29,7 @@ func DecodeSong(t SongType, r io.ReadSeekCloser) (streamer beep.StreamSeekCloser
 func decodeSong(t SongType, r io.ReadSeekCloser, duration time.Duration, finalized bool) (streamer beep.StreamSeekCloser, format beep.Format, err error) {
 	switch t {
 	case Mp3:
-		gaplessDelay, gaplessPadding := mp3GaplessSamples(r)
+		gaplessDelay, gaplessPadding, hasGaplessPadding := mp3GaplessSamples(r)
 		switch configs.AppConfig.Player.Beep.Mp3Decoder {
 		case types.BeepMiniMp3Decoder:
 			minimp3pkg.BufferSize = 1024 * 50
@@ -35,12 +37,10 @@ func decodeSong(t SongType, r io.ReadSeekCloser, duration time.Duration, finaliz
 		default:
 			streamer, format, err = mp3.Decode(r)
 			if err == nil && configs.AppConfig.Player.Beep.Gapless {
-				if finalized && duration > 0 && format.SampleRate > 0 {
+				if finalized && !hasGaplessPadding && duration > 0 && format.SampleRate > 0 {
 					target := int(math.Round(duration.Seconds() * float64(format.SampleRate)))
 					decoded := streamer.Len() - gaplessDelay
-					if target > 0 && decoded > target {
-						gaplessPadding = decoded - target
-					}
+					gaplessPadding = estimateMP3Padding(decoded, target, format.SampleRate)
 				}
 			}
 			if err == nil && configs.AppConfig.Player.Beep.Gapless && (gaplessDelay > 0 || gaplessPadding > 0) {
@@ -57,6 +57,15 @@ func decodeSong(t SongType, r io.ReadSeekCloser, duration time.Duration, finaliz
 		err = errors.Errorf("Unknown song type(%d)", t)
 	}
 	return
+}
+
+func estimateMP3Padding(decoded, target int, sampleRate beep.SampleRate) int {
+	padding := decoded - target
+	maxPadding := int(maxEstimatedMP3Padding.Seconds() * float64(sampleRate))
+	if target <= 0 || padding <= 0 || padding > maxPadding {
+		return 0
+	}
+	return padding
 }
 
 type trimmedMP3 struct {
@@ -122,7 +131,7 @@ func (d *trimmedMP3) Seek(pos int) error {
 	return nil
 }
 
-func mp3GaplessSamples(r io.ReadSeeker) (delay, padding int) {
+func mp3GaplessSamples(r io.ReadSeeker) (delay, padding int, hasPadding bool) {
 	if _, err := r.Seek(0, io.SeekStart); err != nil {
 		return
 	}
@@ -142,22 +151,24 @@ func mp3GaplessSamples(r io.ReadSeeker) (delay, padding int) {
 			break
 		}
 		value := uint32(data[i+21])<<16 | uint32(data[i+22])<<8 | uint32(data[i+23])
-		return int(value >> 12), int(value & 0xfff)
+		return int(value >> 12), int(value & 0xfff), true
 	}
 	// FFmpeg-authored MP3s commonly retain Xing/Info but omit a LAME delay
 	// field. Their demuxer-visible start skip is the standard 576 encoder plus
 	// 529 decoder samples.
 	header := string(data[:metadataEnd])
 	if strings.Contains(header, "Xing") || strings.Contains(header, "Info") {
-		return 1105, 0
+		return 1105, 0, false
 	}
 	// Some encoders write the same values in the iTunSMPB ID3 text frame.
 	if i := strings.Index(string(data), "iTunSMPB"); i >= 0 {
 		fields := strings.Fields(string(data[i:]))
 		if len(fields) >= 4 {
-			d, _ := strconv.ParseInt(fields[2], 16, 32)
-			p, _ := strconv.ParseInt(fields[3], 16, 32)
-			return int(d), int(p)
+			d, delayErr := strconv.ParseInt(fields[2], 16, 32)
+			p, paddingErr := strconv.ParseInt(fields[3], 16, 32)
+			if delayErr == nil && paddingErr == nil {
+				return int(d), int(p), true
+			}
 		}
 	}
 	return

--- a/internal/player/beep_gapless.go
+++ b/internal/player/beep_gapless.go
@@ -181,13 +181,16 @@ func prepareGapless(ctx context.Context, fromID int64, music URLMusic, outputRat
 		}
 	}
 	if err != nil || reader == nil {
+		if reader != nil {
+			_ = reader.Close()
+		}
 		slog.Warn("gapless preload open error", "song_id", music.Id, "error", err)
 		return nil
 	}
-	defer reader.Close()
 
 	file, err := os.CreateTemp(app.RuntimeDir(), "beep_gapless_*")
 	if err != nil {
+		_ = reader.Close()
 		return nil
 	}
 	bytes, copyErr := iox.CopyClose(ctx, file, reader)

--- a/internal/player/beep_gapless.go
+++ b/internal/player/beep_gapless.go
@@ -53,12 +53,19 @@ func newGaplessState() *gaplessState {
 
 func streamAcrossBoundary(samples [][2]float64, current beep.Streamer, next func() beep.Streamer) (n int, ok, switched bool) {
 	n, ok = current.Stream(samples)
-	if ok || next == nil || n == len(samples) {
+	if ok || next == nil {
 		return n, ok, false
 	}
 	nextStreamer := next()
 	if nextStreamer == nil {
 		return n, ok, false
+	}
+	// If the current stream ends exactly at the buffer boundary, switch now
+	// but leave the next stream untouched for the following callback. Returning
+	// ok=true prevents beep.Seq from firing its completion callback between the
+	// two tracks.
+	if n == len(samples) {
+		return n, true, true
 	}
 	more, nextOK := nextStreamer.Stream(samples[n:])
 	deClickBoundary(samples, n, more)

--- a/internal/player/beep_gapless.go
+++ b/internal/player/beep_gapless.go
@@ -1,0 +1,211 @@
+package player
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/gopxl/beep"
+
+	"github.com/go-musicfox/go-musicfox/utils/app"
+	"github.com/go-musicfox/go-musicfox/utils/iox"
+)
+
+type preparedGapless struct {
+	fromID int64
+	music  URLMusic
+	raw    beep.StreamSeekCloser
+	stream beep.Streamer
+	format beep.Format
+	file   *os.File
+}
+
+func (p *preparedGapless) close() {
+	if p.raw != nil {
+		_ = p.raw.Close()
+	}
+	if p.file != nil {
+		name := p.file.Name()
+		_ = p.file.Close()
+		_ = os.Remove(name)
+	}
+}
+
+type gaplessState struct {
+	mu          sync.Mutex
+	generation  atomic.Int64
+	preloaded   *preparedGapless
+	preloading  int64
+	cancelLoad  context.CancelFunc
+	transitions chan GaplessTransition
+}
+
+func newGaplessState() *gaplessState {
+	return &gaplessState{
+		transitions: make(chan GaplessTransition, 1),
+	}
+}
+
+func streamAcrossBoundary(samples [][2]float64, current beep.Streamer, next func() beep.Streamer) (n int, ok, switched bool) {
+	n, ok = current.Stream(samples)
+	if ok || next == nil || n == len(samples) {
+		return n, ok, false
+	}
+	nextStreamer := next()
+	if nextStreamer == nil {
+		return n, ok, false
+	}
+	more, nextOK := nextStreamer.Stream(samples[n:])
+	deClickBoundary(samples, n, more)
+	return n + more, nextOK, true
+}
+
+const gaplessDeClickSamples = 64
+
+// MP3 encoders can leave a small PCM discontinuity at an otherwise gapless
+// boundary. Fade only the DC step into the next track; this is short enough
+// to avoid audible crossfade while removing the sharp click.
+func deClickBoundary(samples [][2]float64, boundary, nextCount int) {
+	if boundary == 0 || nextCount == 0 {
+		return
+	}
+	width := gaplessDeClickSamples
+	if width > nextCount {
+		width = nextCount
+	}
+	last := samples[boundary-1]
+	first := samples[boundary]
+	correction := [2]float64{last[0] - first[0], last[1] - first[1]}
+	for i := 0; i < width; i++ {
+		factor := 1.0
+		if width > 1 {
+			factor = 1 - float64(i)/float64(width-1)
+		}
+		samples[boundary+i][0] += correction[0] * factor
+		samples[boundary+i][1] += correction[1] * factor
+	}
+}
+
+func (g *gaplessState) cancel() {
+	g.generation.Add(1)
+	g.mu.Lock()
+	if g.cancelLoad != nil {
+		g.cancelLoad()
+		g.cancelLoad = nil
+	}
+	if g.preloaded != nil {
+		g.preloaded.close()
+		g.preloaded = nil
+	}
+	g.mu.Unlock()
+}
+
+func (g *gaplessState) preload(fromID int64, music URLMusic, outputRate beep.SampleRate, client *http.Client, closed <-chan struct{}) {
+	id := g.generation.Add(1)
+	ctx, cancel := context.WithCancel(context.Background())
+	g.mu.Lock()
+	if g.cancelLoad != nil {
+		g.cancelLoad()
+	}
+	if g.preloaded != nil {
+		g.preloaded.close()
+		g.preloaded = nil
+	}
+	g.preloading = music.Id
+	g.cancelLoad = cancel
+	g.mu.Unlock()
+
+	go func() {
+		prepared := prepareGapless(ctx, fromID, music, outputRate, client, closed)
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		if id != g.generation.Load() || g.preloading != music.Id {
+			if prepared != nil {
+				prepared.close()
+			}
+			return
+		}
+		g.preloading = 0
+		g.cancelLoad = nil
+		g.preloaded = prepared
+	}()
+}
+
+func (g *gaplessState) takeIfReady(currentID int64) *preparedGapless {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.preloaded == nil || g.preloaded.fromID != currentID {
+		return nil
+	}
+	prepared := g.preloaded
+	g.preloaded = nil
+	return prepared
+}
+
+func prepareGapless(ctx context.Context, fromID int64, music URLMusic, outputRate beep.SampleRate, client *http.Client, closed <-chan struct{}) *preparedGapless {
+	select {
+	case <-closed:
+		return nil
+	default:
+	}
+	var reader io.ReadCloser
+	var err error
+	var response *http.Response
+	if strings.HasPrefix(music.URL, "file://") {
+		reader, err = os.Open(strings.TrimPrefix(music.URL, "file://"))
+	} else {
+		request, requestErr := http.NewRequestWithContext(ctx, http.MethodGet, music.URL, nil)
+		if requestErr != nil {
+			return nil
+		}
+		response, err = client.Do(request)
+		if response != nil {
+			reader = response.Body
+			if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+				slog.Warn("gapless preload http error", "song_id", music.Id, "status", response.StatusCode)
+				_ = reader.Close()
+				return nil
+			}
+		}
+	}
+	if err != nil || reader == nil {
+		slog.Warn("gapless preload open error", "song_id", music.Id, "error", err)
+		return nil
+	}
+	defer reader.Close()
+
+	file, err := os.CreateTemp(app.RuntimeDir(), "beep_gapless_*")
+	if err != nil {
+		return nil
+	}
+	bytes, copyErr := iox.CopyClose(ctx, file, reader)
+	if copyErr != nil {
+		slog.Warn("gapless preload download error", "song_id", music.Id, "bytes", bytes, "error", copyErr)
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return nil
+	}
+	if _, err = file.Seek(0, io.SeekStart); err != nil {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return nil
+	}
+	raw, format, err := decodeSong(music.Type, file, music.Duration)
+	if err != nil {
+		slog.Warn("gapless preload decode error", "song_id", music.Id, "bytes", bytes, "error", err)
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return nil
+	}
+	var stream beep.Streamer = raw
+	if format.SampleRate != outputRate {
+		stream = beep.Resample(resampleQuiality, format.SampleRate, outputRate, raw)
+	}
+	slog.Info("gapless preload ready", "song_id", music.Id, "bytes", bytes, "sample_rate", format.SampleRate, "samples", raw.Len())
+	return &preparedGapless{fromID: fromID, music: music, raw: raw, stream: stream, format: format, file: file}
+}

--- a/internal/player/beep_gapless.go
+++ b/internal/player/beep_gapless.go
@@ -195,7 +195,7 @@ func prepareGapless(ctx context.Context, fromID int64, music URLMusic, outputRat
 		_ = os.Remove(file.Name())
 		return nil
 	}
-	raw, format, err := decodeSong(music.Type, file, music.Duration)
+	raw, format, err := decodeSong(music.Type, file, music.Duration, true)
 	if err != nil {
 		slog.Warn("gapless preload decode error", "song_id", music.Id, "bytes", bytes, "error", err)
 		_ = file.Close()

--- a/internal/player/beep_gapless_test.go
+++ b/internal/player/beep_gapless_test.go
@@ -24,7 +24,7 @@ func TestStreamAcrossBoundaryFillsSameBufferWithoutSilence(t *testing.T) {
 
 func TestTrimmedMP3RemovesEncoderPadding(t *testing.T) {
 	raw := &sampleSeekStreamer{samples: [][2]float64{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}}}
-	stream := &trimmedMP3{StreamSeekCloser: raw, start: 1, end: 2}
+	stream := &trimmedMP3{StreamSeekCloser: raw, start: 1, end: 2, trimEnd: true}
 	buffer := make([][2]float64, 3)
 	n, ok := stream.Stream(buffer)
 	if n != 3 || ok {
@@ -44,6 +44,19 @@ func TestTrimmedMP3RemovesEncoderPadding(t *testing.T) {
 	var one [1][2]float64
 	if n, _ := stream.Stream(one[:]); n != 1 || one[0][0] != 2 {
 		t.Fatalf("seeked sample = %v", one[0][0])
+	}
+}
+
+func TestTrimmedMP3DoesNotUseFixedLengthWhileStreaming(t *testing.T) {
+	raw := &sampleSeekStreamer{samples: [][2]float64{{0, 0}, {1, 1}, {2, 2}, {3, 3}}}
+	stream := &trimmedMP3{StreamSeekCloser: raw, start: 1, end: 2}
+	buffer := make([][2]float64, 3)
+	n, ok := stream.Stream(buffer)
+	if n != 3 || ok {
+		t.Fatalf("n=%d ok=%v, want 3 false at the underlying EOF", n, ok)
+	}
+	if stream.Len() != 3 {
+		t.Fatalf("streaming logical length=%d, want underlying length minus start", stream.Len())
 	}
 }
 

--- a/internal/player/beep_gapless_test.go
+++ b/internal/player/beep_gapless_test.go
@@ -1,6 +1,7 @@
 package player
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/gopxl/beep"
@@ -71,6 +72,55 @@ func TestTrimmedMP3DoesNotUseFixedLengthWhileStreaming(t *testing.T) {
 	}
 	if stream.Len() != 3 {
 		t.Fatalf("streaming logical length=%d, want underlying length minus start", stream.Len())
+	}
+}
+
+func TestEstimateMP3PaddingIsConservative(t *testing.T) {
+	const rate = beep.SampleRate(44100)
+	maxPadding := int(maxEstimatedMP3Padding.Seconds() * float64(rate))
+	for _, test := range []struct {
+		name        string
+		decoded     int
+		target      int
+		wantPadding int
+	}{
+		{name: "typical padding", decoded: 101000, target: 100000, wantPadding: 1000},
+		{name: "maximum padding", decoded: 100000 + maxPadding, target: 100000, wantPadding: maxPadding},
+		{name: "duration mismatch", decoded: 100001 + maxPadding, target: 100000, wantPadding: 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := estimateMP3Padding(test.decoded, test.target, rate); got != test.wantPadding {
+				t.Fatalf("padding=%d, want %d", got, test.wantPadding)
+			}
+		})
+	}
+}
+
+func TestMP3GaplessSamplesTreatsExplicitZeroPaddingAsReliable(t *testing.T) {
+	lame := make([]byte, 64)
+	copy(lame[4:], "LAME")
+	copy(lame[4+21:], []byte{0x45, 0x10, 0x00}) // delay=0x451, padding=0
+
+	for _, test := range []struct {
+		name string
+		data []byte
+	}{
+		{name: "LAME", data: lame},
+		{name: "iTunSMPB", data: []byte("iTunSMPB 00000000 00000451 00000000")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			delay, padding, hasPadding := mp3GaplessSamples(bytes.NewReader(test.data))
+			if delay != 0x451 || padding != 0 || !hasPadding {
+				t.Fatalf("delay=%d padding=%d hasPadding=%v", delay, padding, hasPadding)
+			}
+		})
+	}
+}
+
+func TestMP3GaplessSamplesRejectsInvalidITunSMPB(t *testing.T) {
+	delay, padding, hasPadding := mp3GaplessSamples(bytes.NewReader([]byte("iTunSMPB 00000000 invalid invalid")))
+	if delay != 0 || padding != 0 || hasPadding {
+		t.Fatalf("delay=%d padding=%d hasPadding=%v, want invalid metadata ignored", delay, padding, hasPadding)
 	}
 }
 

--- a/internal/player/beep_gapless_test.go
+++ b/internal/player/beep_gapless_test.go
@@ -22,6 +22,20 @@ func TestStreamAcrossBoundaryFillsSameBufferWithoutSilence(t *testing.T) {
 	}
 }
 
+func TestStreamAcrossBoundaryKeepsExactBufferBoundaryAlive(t *testing.T) {
+	current := &sampleStreamer{samples: [][2]float64{{1, 1}, {2, 2}}}
+	next := &sampleStreamer{samples: [][2]float64{{3, 3}}}
+	buffer := make([][2]float64, 2)
+
+	n, ok, switched := streamAcrossBoundary(buffer, current, func() beep.Streamer { return next })
+	if n != len(buffer) || !ok || !switched {
+		t.Fatalf("n=%d ok=%v switched=%v, want exact-boundary switch", n, ok, switched)
+	}
+	if next.pos != 0 {
+		t.Fatalf("next stream advanced to %d, want it untouched until the next callback", next.pos)
+	}
+}
+
 func TestTrimmedMP3RemovesEncoderPadding(t *testing.T) {
 	raw := &sampleSeekStreamer{samples: [][2]float64{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}}}
 	stream := &trimmedMP3{StreamSeekCloser: raw, start: 1, end: 2, trimEnd: true}

--- a/internal/player/beep_gapless_test.go
+++ b/internal/player/beep_gapless_test.go
@@ -1,0 +1,93 @@
+package player
+
+import (
+	"testing"
+
+	"github.com/gopxl/beep"
+)
+
+func TestStreamAcrossBoundaryFillsSameBufferWithoutSilence(t *testing.T) {
+	current := &sampleStreamer{samples: [][2]float64{{1, 1}, {2, 2}}}
+	next := &sampleStreamer{samples: [][2]float64{{3, 3}, {4, 4}, {5, 5}}}
+	buffer := make([][2]float64, 4)
+
+	n, ok, switched := streamAcrossBoundary(buffer, current, func() beep.Streamer { return next })
+	if n != 4 || !ok || !switched {
+		t.Fatalf("n=%d ok=%v switched=%v", n, ok, switched)
+	}
+	for i, want := range []float64{1, 2, 2, 4} {
+		if buffer[i][0] != want || buffer[i][1] != want {
+			t.Fatalf("sample %d = %v, want {%v %v}", i, buffer[i], want, want)
+		}
+	}
+}
+
+func TestTrimmedMP3RemovesEncoderPadding(t *testing.T) {
+	raw := &sampleSeekStreamer{samples: [][2]float64{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}}}
+	stream := &trimmedMP3{StreamSeekCloser: raw, start: 1, end: 2}
+	buffer := make([][2]float64, 3)
+	n, ok := stream.Stream(buffer)
+	if n != 3 || ok {
+		t.Fatalf("n=%d ok=%v", n, ok)
+	}
+	for i, want := range []float64{1, 2, 3} {
+		if buffer[i][0] != want {
+			t.Fatalf("sample %d = %v, want %v", i, buffer[i][0], want)
+		}
+	}
+	if stream.Len() != 3 || stream.Position() != 3 {
+		t.Fatalf("len=%d position=%d", stream.Len(), stream.Position())
+	}
+	if err := stream.Seek(1); err != nil {
+		t.Fatal(err)
+	}
+	var one [1][2]float64
+	if n, _ := stream.Stream(one[:]); n != 1 || one[0][0] != 2 {
+		t.Fatalf("seeked sample = %v", one[0][0])
+	}
+}
+
+func TestDeClickBoundarySmoothsOnlyTheBoundary(t *testing.T) {
+	samples := [][2]float64{{0, 0}, {1, 1}, {10, 10}, {10, 10}, {10, 10}}
+	deClickBoundary(samples, 2, 3)
+	if samples[2][0] != 1 {
+		t.Fatalf("first next sample = %v, want 1", samples[2][0])
+	}
+	if samples[3][0] != 5.5 || samples[4][0] != 10 {
+		t.Fatalf("boundary correction = %v, %v, want 5.5, 10", samples[3][0], samples[4][0])
+	}
+}
+
+type sampleStreamer struct {
+	samples [][2]float64
+	pos     int
+}
+
+func (s *sampleStreamer) Stream(dst [][2]float64) (int, bool) {
+	n := copy(dst, s.samples[s.pos:])
+	s.pos += n
+	return n, s.pos < len(s.samples)
+}
+
+func (s *sampleStreamer) Err() error { return nil }
+
+var _ beep.Streamer = (*sampleStreamer)(nil)
+
+type sampleSeekStreamer struct {
+	samples [][2]float64
+	pos     int
+}
+
+func (s *sampleSeekStreamer) Stream(dst [][2]float64) (int, bool) {
+	n := copy(dst, s.samples[s.pos:])
+	s.pos += n
+	return n, s.pos < len(s.samples)
+}
+
+func (s *sampleSeekStreamer) Err() error         { return nil }
+func (s *sampleSeekStreamer) Len() int           { return len(s.samples) }
+func (s *sampleSeekStreamer) Position() int      { return s.pos }
+func (s *sampleSeekStreamer) Seek(pos int) error { s.pos = pos; return nil }
+func (s *sampleSeekStreamer) Close() error       { return nil }
+
+var _ beep.StreamSeekCloser = (*sampleSeekStreamer)(nil)

--- a/internal/player/beep_player.go
+++ b/internal/player/beep_player.go
@@ -532,64 +532,79 @@ func (p *beepPlayer) reset() {
 }
 
 func (p *beepPlayer) streamer(samples [][2]float64) (n int, ok bool) {
-	p.l.Lock()
-	defer p.l.Unlock()
-
-	pos := p.curStreamer.Position()
-	current := beep.Streamer(p.curStreamer)
-	if p.gaplessOutput != nil {
-		current = p.gaplessOutput
-	}
-	var prepared *preparedGapless
-	n, ok, switched := streamAcrossBoundary(samples, current, func() beep.Streamer {
-		if p.gapless != nil {
-			prepared = p.gapless.takeIfReady(p.curMusic.Id)
-		}
-		if prepared == nil {
-			return nil
-		}
-		return prepared.stream
-	})
-	if switched {
-		p.finishGapless(prepared)
-	}
-
-	// Spectrum: feed PCM samples to analyzer
-	if p.spectrumConsumer != nil && n > 0 {
-		samplesL := make([]float32, n)
-		samplesR := make([]float32, n)
-		for i := 0; i < n; i++ {
-			samplesL[i] = float32(samples[i][0])
-			samplesR[i] = float32(samples[i][1])
-		}
-		p.spectrumConsumer(float64(sampleRate), samplesL, samplesR)
-	}
-
-	err := p.curStreamer.Err()
-	if err == nil && (ok || p.cacheDownloaded) {
-		return
-	}
-	p.pausedNoLock()
-
+	filled := 0
 	retry := 4
-	for !ok && retry > 0 {
-		if p.curMusic.Type == Flac {
-			if err = p.curStreamer.Seek(pos); err != nil {
-				return
-			}
+	for {
+		p.l.Lock()
+		if p.curStreamer == nil || filled >= len(samples) {
+			p.l.Unlock()
+			return filled, filled == len(samples)
 		}
-		errorx.ResetError(p.curStreamer)
 
+		current := beep.Streamer(p.curStreamer)
+		if p.gaplessOutput != nil {
+			current = p.gaplessOutput
+		}
+		var prepared *preparedGapless
+		chunk, streamOK, switched := streamAcrossBoundary(samples[filled:], current, func() beep.Streamer {
+			if p.gapless != nil {
+				prepared = p.gapless.takeIfReady(p.curMusic.Id)
+			}
+			if prepared == nil {
+				return nil
+			}
+			return prepared.stream
+		})
+		filled += chunk
+		if switched {
+			p.finishGapless(prepared)
+		}
+
+		// Spectrum: feed PCM samples to analyzer.
+		if p.spectrumConsumer != nil && chunk > 0 {
+			samplesL := make([]float32, chunk)
+			samplesR := make([]float32, chunk)
+			for i := 0; i < chunk; i++ {
+				samplesL[i] = float32(samples[filled-chunk+i][0])
+				samplesR[i] = float32(samples[filled-chunk+i][1])
+			}
+			p.spectrumConsumer(float64(sampleRate), samplesL, samplesR)
+		}
+
+		err := p.curStreamer.Err()
+		downloaded := p.cacheDownloaded
+		if err == nil && (streamOK || downloaded) {
+			p.l.Unlock()
+			return filled, streamOK
+		}
+		if filled == len(samples) {
+			p.l.Unlock()
+			if err == nil && !downloaded {
+				return filled, true
+			}
+			return filled, streamOK
+		}
+		if retry == 0 {
+			p.resumeNoLock()
+			p.l.Unlock()
+			return filled, streamOK
+		}
+
+		p.pausedNoLock()
+		p.l.Unlock()
 		select {
 		case <-time.After(time.Second * 5):
-			n, ok = p.curStreamer.Stream(samples)
+			retry--
 		case <-p.close:
-			return
+			return filled, streamOK
 		}
-		retry--
+		p.l.Lock()
+		if p.curStreamer != nil {
+			errorx.ResetError(p.curStreamer)
+			p.resumeNoLock()
+		}
+		p.l.Unlock()
 	}
-	p.resumeNoLock()
-	return
 }
 
 func (p *beepPlayer) finishGapless(prepared *preparedGapless) {

--- a/internal/player/beep_player.go
+++ b/internal/player/beep_player.go
@@ -180,7 +180,7 @@ func (p *beepPlayer) listen() {
 						lastStreamer := p.curStreamer
 						defer func() { _ = lastStreamer.Close() }()
 						pos := lastStreamer.Position()
-						if p.curStreamer, p.curFormat, err = decodeSong(p.curMusic.Type, cacheReader, p.curMusic.Duration); err != nil {
+						if p.curStreamer, p.curFormat, err = decodeSong(p.curMusic.Type, cacheReader, p.curMusic.Duration, true); err != nil {
 							p.stopNoLock()
 							return
 						}
@@ -213,7 +213,7 @@ func (p *beepPlayer) listen() {
 				}
 			}
 
-			if p.curStreamer, p.curFormat, err = decodeSong(p.curMusic.Type, p.cacheReader, p.curMusic.Duration); err != nil {
+			if p.curStreamer, p.curFormat, err = decodeSong(p.curMusic.Type, p.cacheReader, p.curMusic.Duration, p.cacheDownloaded); err != nil {
 				p.stopNoLock()
 				goto nextLoop
 			}

--- a/internal/player/beep_player.go
+++ b/internal/player/beep_player.go
@@ -609,7 +609,10 @@ func (p *beepPlayer) streamer(samples [][2]float64) (n int, ok bool) {
 
 func (p *beepPlayer) finishGapless(prepared *preparedGapless) {
 	old := p.curStreamer
-	playedTime := p.timer.ActualRuntime()
+	var playedTime time.Duration
+	if p.timer != nil {
+		playedTime = p.timer.ActualRuntime()
+	}
 	if p.cacheReader != nil {
 		_ = p.cacheReader.Close()
 	}
@@ -627,7 +630,9 @@ func (p *beepPlayer) finishGapless(prepared *preparedGapless) {
 	p.cacheReader = prepared.file
 	p.gaplessCachePath = prepared.file.Name()
 	p.cacheDownloaded = true
-	p.timer.Reset()
+	if p.timer != nil {
+		p.timer.Reset()
+	}
 	if old != nil {
 		_ = old.Close()
 	}

--- a/internal/player/beep_player.go
+++ b/internal/player/beep_player.go
@@ -38,20 +38,24 @@ type beepPlayer struct {
 	curMusic URLMusic
 	timer    *timex.Timer
 
-	cacheReader     *os.File
-	cacheWriter     *os.File
-	cacheDownloaded bool
+	cacheReader      *os.File
+	cacheWriter      *os.File
+	cacheDownloaded  bool
+	gaplessCachePath string
 
 	curStreamer beep.StreamSeekCloser
 	curFormat   beep.Format
 
-	state      atomic.Uint32 // types.State, atomically read/written (setState runs under p.l; State() is called from the UI thread)
-	ctrl       *beep.Ctrl
-	volume     *effects.Volume
-	timeChan   chan time.Duration
-	stateChan  chan types.State
-	musicChan  chan URLMusic
-	httpClient *http.Client
+	state             atomic.Uint32 // types.State, atomically read/written (setState runs under p.l; State() is called from the UI thread)
+	ctrl              *beep.Ctrl
+	volume            *effects.Volume
+	timeChan          chan time.Duration
+	stateChan         chan types.State
+	musicChan         chan URLMusic
+	httpClient        *http.Client
+	gapless           *gaplessState
+	gaplessOutput     beep.Streamer
+	gaplessOutputRate beep.SampleRate
 
 	close chan struct{}
 
@@ -73,6 +77,9 @@ func NewBeepPlayer() *beepPlayer {
 		},
 		httpClient: &http.Client{},
 		close:      make(chan struct{}),
+	}
+	if configs.AppConfig.Player.Beep.Gapless {
+		p.gapless = newGaplessState()
 	}
 
 	if configs.AppConfig.Main.Visualizer.Enable || (configs.AppConfig.Main.Lyric.DesktopLyrics.SpectrumEnabled && desktopLyricsAvailable) {
@@ -173,7 +180,7 @@ func (p *beepPlayer) listen() {
 						lastStreamer := p.curStreamer
 						defer func() { _ = lastStreamer.Close() }()
 						pos := lastStreamer.Position()
-						if p.curStreamer, p.curFormat, err = DecodeSong(p.curMusic.Type, cacheReader); err != nil {
+						if p.curStreamer, p.curFormat, err = decodeSong(p.curMusic.Type, cacheReader, p.curMusic.Duration); err != nil {
 							p.stopNoLock()
 							return
 						}
@@ -206,7 +213,7 @@ func (p *beepPlayer) listen() {
 				}
 			}
 
-			if p.curStreamer, p.curFormat, err = DecodeSong(p.curMusic.Type, p.cacheReader); err != nil {
+			if p.curStreamer, p.curFormat, err = decodeSong(p.curMusic.Type, p.cacheReader, p.curMusic.Duration); err != nil {
 				p.stopNoLock()
 				goto nextLoop
 			}
@@ -261,6 +268,32 @@ func (p *beepPlayer) Play(music URLMusic) {
 	case p.musicChan <- music:
 	case <-timer.C:
 	}
+}
+
+func (p *beepPlayer) Preload(music URLMusic) {
+	if p.gapless != nil {
+		p.l.Lock()
+		fromID := p.curMusic.Id
+		outputRate := p.gaplessOutputRate
+		if outputRate == 0 {
+			outputRate = p.curFormat.SampleRate
+		}
+		p.l.Unlock()
+		p.gapless.preload(fromID, music, outputRate, p.httpClient, p.close)
+	}
+}
+
+func (p *beepPlayer) CancelPreload() {
+	if p.gapless != nil {
+		p.gapless.cancel()
+	}
+}
+
+func (p *beepPlayer) GaplessTransitionChan() <-chan GaplessTransition {
+	if p.gapless == nil {
+		return nil
+	}
+	return p.gapless.transitions
 }
 
 func (p *beepPlayer) CurMusic() URLMusic {
@@ -455,6 +488,7 @@ func (p *beepPlayer) Toggle() {
 func (p *beepPlayer) Close() {
 	p.l.Lock()
 	defer p.l.Unlock()
+	p.CancelPreload()
 
 	if p.timer != nil {
 		p.timer.Stop()
@@ -471,6 +505,7 @@ func (p *beepPlayer) Close() {
 }
 
 func (p *beepPlayer) reset() {
+	p.CancelPreload()
 	// 关闭旧计时器
 	if p.timer != nil {
 		p.timer.Stop()
@@ -481,12 +516,18 @@ func (p *beepPlayer) reset() {
 	if p.cacheWriter != nil {
 		_ = p.cacheWriter.Close()
 	}
+	if p.gaplessCachePath != "" {
+		_ = os.Remove(p.gaplessCachePath)
+		p.gaplessCachePath = ""
+	}
 	if p.curStreamer != nil {
 		_ = p.curStreamer.Close()
 		p.curStreamer = nil
 	}
 	p.cacheDownloaded = false
 	p.spectrumConsumer = nil
+	p.gaplessOutput = nil
+	p.gaplessOutputRate = 0
 	speaker.Clear()
 }
 
@@ -495,7 +536,23 @@ func (p *beepPlayer) streamer(samples [][2]float64) (n int, ok bool) {
 	defer p.l.Unlock()
 
 	pos := p.curStreamer.Position()
-	n, ok = p.curStreamer.Stream(samples)
+	current := beep.Streamer(p.curStreamer)
+	if p.gaplessOutput != nil {
+		current = p.gaplessOutput
+	}
+	var prepared *preparedGapless
+	n, ok, switched := streamAcrossBoundary(samples, current, func() beep.Streamer {
+		if p.gapless != nil {
+			prepared = p.gapless.takeIfReady(p.curMusic.Id)
+		}
+		if prepared == nil {
+			return nil
+		}
+		return prepared.stream
+	})
+	if switched {
+		p.finishGapless(prepared)
+	}
 
 	// Spectrum: feed PCM samples to analyzer
 	if p.spectrumConsumer != nil && n > 0 {
@@ -535,7 +592,40 @@ func (p *beepPlayer) streamer(samples [][2]float64) (n int, ok bool) {
 	return
 }
 
+func (p *beepPlayer) finishGapless(prepared *preparedGapless) {
+	old := p.curStreamer
+	playedTime := p.timer.ActualRuntime()
+	if p.cacheReader != nil {
+		_ = p.cacheReader.Close()
+	}
+	if p.cacheWriter != nil {
+		_ = p.cacheWriter.Close()
+		p.cacheWriter = nil
+	}
+	if p.gaplessCachePath != "" {
+		_ = os.Remove(p.gaplessCachePath)
+	}
+	p.curMusic = prepared.music
+	p.curStreamer = prepared.raw
+	p.curFormat = prepared.format
+	p.gaplessOutput = prepared.stream
+	p.cacheReader = prepared.file
+	p.gaplessCachePath = prepared.file.Name()
+	p.cacheDownloaded = true
+	p.timer.Reset()
+	if old != nil {
+		_ = old.Close()
+	}
+	select {
+	case p.gapless.transitions <- GaplessTransition{Music: prepared.music, PlayedTime: playedTime}:
+	default:
+	}
+}
+
 func (p *beepPlayer) resampleStreamer(old beep.SampleRate) beep.Streamer {
+	if p.gapless != nil {
+		p.gaplessOutputRate = old
+	}
 	if old == sampleRate {
 		return beep.StreamerFunc(p.streamer)
 	}

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -30,6 +30,20 @@ type Player interface {
 	Close()
 }
 
+// GaplessTransition describes an audio-boundary switch completed by a player.
+type GaplessTransition struct {
+	Music      URLMusic
+	PlayedTime time.Duration
+}
+
+// GaplessPlayer is implemented by players that can prepare the next track and
+// switch streams without inserting silence between audio samples.
+type GaplessPlayer interface {
+	Preload(URLMusic)
+	CancelPreload()
+	GaplessTransitionChan() <-chan GaplessTransition
+}
+
 func NewPlayerFromConfig() Player {
 	cfg := configs.AppConfig
 	var player Player

--- a/internal/ui/player.go
+++ b/internal/ui/player.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/anhoder/foxful-cli/model"
@@ -80,9 +81,13 @@ type Player struct {
 
 	lyricService *lyric.Service
 
-	playErrCount int // 错误计数，当错误连续超过5次，停止播放
-	stateHandler *control.RemoteControl
-	ctrl         chan CtrlSignal
+	playErrCount    int // 错误计数，当错误连续超过5次，停止播放
+	stateHandler    *control.RemoteControl
+	ctrl            chan CtrlSignal
+	gaplessMu       sync.Mutex
+	gaplessPending  int64
+	gaplessLoading  bool
+	gaplessTriedFor int64
 
 	renderTicker *tickerByPlayer // renderTicker 用于渲染
 
@@ -115,6 +120,10 @@ func NewPlayer(n *Netease, lyricService *lyric.Service) *Player {
 	ctx, p.cancel = context.WithCancel(context.Background())
 
 	p.Player = player.NewPlayerFromConfig()
+	var gaplessTransitions <-chan player.GaplessTransition
+	if gapless, ok := p.Player.(player.GaplessPlayer); ok {
+		gaplessTransitions = gapless.GaplessTransitionChan()
+	}
 	p.stateHandler = control.NewRemoteControl(p, p.PlayingInfo())
 
 	p.renderTicker = newTickerByPlayer(p)
@@ -138,9 +147,9 @@ func NewPlayer(n *Netease, lyricService *lyric.Service) *Player {
 			case <-ctx.Done():
 				return
 			case s := <-p.StateChan():
-			p.stateHandler.SetPlayingInfo(p.PlayingInfo())
-			p.updateDesktopLyrics()
-			if s != types.Stopped {
+				p.stateHandler.SetPlayingInfo(p.PlayingInfo())
+				p.updateDesktopLyrics()
+				if s != types.Stopped {
 					p.netease.Rerender(false)
 					break
 				}
@@ -155,6 +164,8 @@ func NewPlayer(n *Netease, lyricService *lyric.Service) *Player {
 			select {
 			case <-ctx.Done():
 				return
+			case transition := <-gaplessTransitions:
+				p.commitGaplessTransition(transition)
 			case duration := <-p.TimeChan():
 				if pos := p.PassedTime(); p.mprisPosThrottle.shouldEmit(pos, time.Now()) {
 					p.stateHandler.SetPosition(pos)
@@ -162,6 +173,7 @@ func NewPlayer(n *Netease, lyricService *lyric.Service) *Player {
 				if duration.Seconds()-p.CurMusic().Duration.Seconds() > 10 {
 					p.NextSong(false)
 				}
+				p.maybePreloadGapless(duration)
 
 				p.lyricService.UpdatePosition(duration)
 
@@ -240,6 +252,7 @@ func (p *Player) LocatePlayingSong() {
 
 // PlaySong 播放歌曲
 func (p *Player) PlaySong(song structs.Song, direction PlayDirection) {
+	p.cancelGaplessPreload()
 	p.reporter.ReportEnd(p.PlayedTime())
 
 	loading := model.NewLoading(p.netease.MustMain())
@@ -323,6 +336,7 @@ func (p *Player) Playlist() []structs.Song {
 }
 
 func (p *Player) InitSongManager(index int, playlist []structs.Song) {
+	p.cancelGaplessPreload()
 	_ = p.playlistManager.Initialize(index, playlist)
 }
 
@@ -401,6 +415,7 @@ func (p *Player) Seek(duration time.Duration) {
 
 // SetMode 设置播放模式
 func (p *Player) SetMode(playMode types.Mode) {
+	p.cancelGaplessPreload()
 	if p.lastMode != p.netease.player.Mode() {
 		p.lastMode = p.netease.player.Mode()
 	}

--- a/internal/ui/player_gapless.go
+++ b/internal/ui/player_gapless.go
@@ -81,6 +81,16 @@ func (p *Player) commitGaplessTransition(transition player.GaplessTransition) {
 		p.gaplessMu.Unlock()
 		return
 	}
+	// The stream boundary can race with the normal Stopped notification. In
+	// that case the playlist manager has already advanced to this song and the
+	// transition event must only finalize gapless bookkeeping, not advance again.
+	if current := p.CurSong(); current.Id == transition.Music.Id {
+		p.gaplessPending = 0
+		p.gaplessLoading = false
+		p.gaplessTriedFor = 0
+		p.gaplessMu.Unlock()
+		return
+	}
 	p.gaplessPending = 0
 	p.gaplessLoading = false
 	p.gaplessTriedFor = 0

--- a/internal/ui/player_gapless.go
+++ b/internal/ui/player_gapless.go
@@ -1,0 +1,119 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/go-musicfox/go-musicfox/internal/configs"
+	"github.com/go-musicfox/go-musicfox/internal/player"
+	"github.com/go-musicfox/go-musicfox/internal/structs"
+	"github.com/go-musicfox/go-musicfox/internal/types"
+	"github.com/go-musicfox/go-musicfox/utils/app"
+	"github.com/go-musicfox/go-musicfox/utils/errorx"
+	"github.com/go-musicfox/go-musicfox/utils/netease"
+	"github.com/go-musicfox/go-musicfox/utils/notify"
+)
+
+func (p *Player) maybePreloadGapless(position time.Duration) {
+	if !configs.AppConfig.Player.Beep.Gapless {
+		return
+	}
+	gapless, ok := p.Player.(player.GaplessPlayer)
+	preloadSeconds := configs.AppConfig.Player.Beep.GaplessPreloadSeconds
+	if preloadSeconds <= 0 {
+		preloadSeconds = 15
+	}
+	if !ok || p.CurMusic().Duration-position > time.Duration(preloadSeconds)*time.Second {
+		return
+	}
+	next, ok := p.peekGaplessSong()
+	if !ok {
+		return
+	}
+	p.gaplessMu.Lock()
+	if p.gaplessLoading || p.gaplessPending == next.Id || p.gaplessTriedFor == p.CurMusic().Id {
+		p.gaplessMu.Unlock()
+		return
+	}
+	p.gaplessLoading = true
+	fromID := p.CurMusic().Id
+	p.gaplessTriedFor = fromID
+	p.gaplessMu.Unlock()
+
+	errorx.Go(func() {
+		url, musicType, err := p.getPlayInfo(next)
+		p.gaplessMu.Lock()
+		defer p.gaplessMu.Unlock()
+		p.gaplessLoading = false
+		if err != nil || url == "" || p.CurMusic().Id != fromID {
+			return
+		}
+		gapless.Preload(player.URLMusic{URL: url, Song: next, Type: player.SongTypeMapping[musicType]})
+		p.gaplessPending = next.Id
+	}, true)
+}
+
+func (p *Player) peekGaplessSong() (structs.Song, bool) {
+	songs, index := p.Playlist(), p.CurSongIndex()
+	if len(songs) == 0 || index < 0 || index >= len(songs) {
+		return structs.Song{}, false
+	}
+	switch p.Mode() {
+	case types.PmOrdered:
+		if index+1 >= len(songs) {
+			return structs.Song{}, false
+		}
+		return songs[index+1], true
+	case types.PmListLoop:
+		return songs[(index+1)%len(songs)], true
+	case types.PmSingleLoop:
+		return songs[index], true
+	default:
+		return structs.Song{}, false
+	}
+}
+
+func (p *Player) commitGaplessTransition(transition player.GaplessTransition) {
+	p.gaplessMu.Lock()
+	if p.gaplessPending != transition.Music.Id || p.CurMusic().Id != transition.Music.Id {
+		p.gaplessMu.Unlock()
+		return
+	}
+	p.gaplessPending = 0
+	p.gaplessLoading = false
+	p.gaplessTriedFor = 0
+	p.gaplessMu.Unlock()
+
+	song, err := p.playlistManager.NextSong(false)
+	if err != nil || song.Id != transition.Music.Id {
+		slog.Warn("gapless playlist transition mismatch", "error", err, "song", transition.Music.Id)
+		return
+	}
+	p.reporter.ReportEnd(transition.PlayedTime)
+	p.reporter.ReportStart(song)
+	errorx.Go(func() { p.lyricService.SetSong(context.Background(), song) }, true)
+	p.LocatePlayingSong()
+	p.stateHandler.SetPlayingInfo(p.PlayingInfo())
+	p.updateDesktopLyrics()
+	p.netease.Rerender(false)
+	go notify.Notify(notify.NotifyContent{
+		Title:   "正在播放: " + song.Name,
+		Text:    fmt.Sprintf("%s - %s", song.ArtistName(), song.Album.Name),
+		Icon:    app.AddResizeParamForPicUrl(song.PicUrl, 60),
+		Url:     netease.WebUrlOfSong(song.Id),
+		GroupId: types.GroupID,
+	})
+}
+
+func (p *Player) cancelGaplessPreload() {
+	if gapless, ok := p.Player.(player.GaplessPlayer); ok {
+		gapless.CancelPreload()
+	}
+	p.gaplessMu.Lock()
+	p.gaplessPending = 0
+	p.gaplessLoading = false
+	p.gaplessTriedFor = 0
+	p.gaplessMu.Unlock()
+}

--- a/internal/ui/player_gapless_test.go
+++ b/internal/ui/player_gapless_test.go
@@ -1,0 +1,53 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/go-musicfox/go-musicfox/internal/playlist"
+	"github.com/go-musicfox/go-musicfox/internal/structs"
+	"github.com/go-musicfox/go-musicfox/internal/types"
+)
+
+func TestPeekGaplessSongDeterministicModes(t *testing.T) {
+	p := &Player{playlistManager: playlist.NewPlaylistManager()}
+	songs := []structs.Song{{Id: 1}, {Id: 2}, {Id: 3}}
+	if err := p.playlistManager.Initialize(1, songs); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		mode types.Mode
+		want int64
+		ok   bool
+	}{
+		{types.PmOrdered, 3, true},
+		{types.PmListLoop, 3, true},
+		{types.PmSingleLoop, 2, true},
+		{types.PmListRandom, 0, false},
+		{types.PmInfRandom, 0, false},
+		{types.PmIntelligent, 0, false},
+	}
+	for _, test := range tests {
+		if err := p.playlistManager.SetPlayMode(test.mode); err != nil {
+			t.Fatal(err)
+		}
+		got, ok := p.peekGaplessSong()
+		if ok != test.ok || got.Id != test.want {
+			t.Errorf("mode %v: got id=%d ok=%v, want id=%d ok=%v", test.mode, got.Id, ok, test.want, test.ok)
+		}
+	}
+}
+
+func TestPeekGaplessSongWrapsListLoop(t *testing.T) {
+	p := &Player{playlistManager: playlist.NewPlaylistManager()}
+	if err := p.playlistManager.Initialize(1, []structs.Song{{Id: 1}, {Id: 2}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.playlistManager.SetPlayMode(types.PmListLoop); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := p.peekGaplessSong()
+	if !ok || got.Id != 1 {
+		t.Fatalf("got id=%d ok=%v, want id=1 ok=true", got.Id, ok)
+	}
+}

--- a/utils/filex/embed/config.toml
+++ b/utils/filex/embed/config.toml
@@ -324,7 +324,8 @@ mouseVolumeStep = 1
 # MP3解码器，可选: "go-mp3", "minimp3"
 # "minimp3" CPU占用更低，但稳定性可能稍逊于 "go-mp3"
 mp3Decoder = "go-mp3"
-# 无缝播放（仅 beep 引擎），默认关闭
+# 无缝播放（仅 beep 引擎），默认关闭；MP3 使用 go-mp3 时会裁剪编码器延迟和尾部填充
+# minimp3 仅支持连续流切换，不处理 MP3 编码器延迟和尾部填充
 gapless = false
 # 开始预加载下一首时，当前歌曲的剩余秒数
 gaplessPreloadSeconds = 15

--- a/utils/filex/embed/config.toml
+++ b/utils/filex/embed/config.toml
@@ -324,6 +324,10 @@ mouseVolumeStep = 1
 # MP3解码器，可选: "go-mp3", "minimp3"
 # "minimp3" CPU占用更低，但稳定性可能稍逊于 "go-mp3"
 mp3Decoder = "go-mp3"
+# 无缝播放（仅 beep 引擎），默认关闭
+gapless = false
+# 开始预加载下一首时，当前歌曲的剩余秒数
+gaplessPreloadSeconds = 15
 
 # `mpd` 引擎专属配置，需要安装mpd
 [player.mpd]

--- a/utils/timex/timer.go
+++ b/utils/timex/timer.go
@@ -49,6 +49,15 @@ func (t *Timer) SetPassed(passed time.Duration) {
 	t.passed = passed
 }
 
+// Reset starts elapsed-time accounting for a new item without interrupting the ticker.
+func (t *Timer) Reset() {
+	t.l.Lock()
+	defer t.l.Unlock()
+	t.passed = 0
+	t.actualRuntime = 0
+	t.lastTick = time.Now()
+}
+
 // Remaining returns how much time is left to end.
 func (t *Timer) Remaining() time.Duration {
 	return t.options.Duration - t.Passed()


### PR DESCRIPTION
### Issue for this PR / 本 PR 关联的 Issue

Closes #

---

### Type of change / 变更类型

- [ ] Refactor | code improvement / 重构 | 代码优化
- [ ] Bug fix / Bug 修复
- [*] New feature / 新功能
- [ ] Documentation / 文档更新

---
 ### What does this PR do? / 本 PR 做了什么？

  为 beep 播放引擎增加可选的无缝播放，默认关闭。

  开启后会提前加载播放列表中的下一首歌曲，并在当前歌曲结束时直接衔接音频流。针对 MP3，还会裁剪编码
  器延迟和尾部填充，并在边界进行约 1.5ms 的去爆音处理。

  配置示例：

  [player.beep]
  gapless = true
  gaplessPreloadSeconds = 15

  ### How did you verify your code works? / 如何验证你的代码有效？

  运行了播放器和 UI 相关测试，并完成 Windows 本地构建。
  实际试听 《Best Friends》: https://music.163.com/m/song?id=1909926107 到 《Is there someone Else?》https://music.163.com/m/song?id=1909927738 
  Else? 声音连续。

  ### Screenshots / recordings / 截图 / 录屏

  非 UI 修改，无截图。

  ### Checklist / 检查清单

  - [x] I have not included unrelated changes in this PR / 本 PR 未包含无关的更改
  - [x] I have tested my changes locally / 我已在本地测试了我的更改
