### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   triage:
     uses: ./.github/workflows/opencode.yml


### PR DESCRIPTION
Potential fix for [https://github.com/go-musicfox/go-musicfox/security/code-scanning/10](https://github.com/go-musicfox/go-musicfox/security/code-scanning/10)

Add an explicit `permissions` block to `.github/workflows/triage.yml` to enforce least privilege for `GITHUB_TOKEN`.  
Best single fix without changing behavior: set workflow-level minimal read permissions so all jobs inherit them unless overridden. For this file, add:

- `permissions:`
  - `contents: read`

Place this near the top level (after `on:` block and before `jobs:`), so it applies to the `triage` job that calls the reusable workflow. This satisfies the CodeQL requirement and documents baseline token scope while keeping functionality unchanged as much as possible.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
