### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -4,6 +4,11 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   prepare:
     if: |


### PR DESCRIPTION
Potential fix for [https://github.com/go-musicfox/go-musicfox/security/code-scanning/9](https://github.com/go-musicfox/go-musicfox/security/code-scanning/9)

Add an explicit top-level `permissions` block in `.github/workflows/review.yml` to enforce least privilege for all jobs in this workflow.

Best single fix without changing functionality:
- Add at workflow root (after `on:` block, before `jobs:`):
  - `contents: read` (needed for basic repository read operations)
  - `pull-requests: write` (needed because the review flow posts PR comments)
  - `issues: write` (needed because workflow instructions say to comment on the issue with “lgtm” when no violations are found)

This keeps behavior intact while constraining token scopes explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
