### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened, edited]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-duplicates:
     if: github.event.action == 'opened'


### PR DESCRIPTION
Potential fix for [https://github.com/go-musicfox/go-musicfox/security/code-scanning/7](https://github.com/go-musicfox/go-musicfox/security/code-scanning/7)

Add an explicit `permissions` block at the workflow root in `.github/workflows/duplicate-issues.yml`, so both jobs inherit the same least-privilege token scopes.  
Best single fix without changing behavior: set only what this workflow needs for issue triage/recheck operations:

- `contents: read` (safe baseline for checkout/metadata access)
- `issues: write` (needed for commenting, label edits, and comment deletion mentioned in prompts)

Place this block directly under `on:` (or under `name:`) and before `jobs:` so it applies to both `check-duplicates` and `recheck-compliance`.

No imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
