### PR TITLE
fix(AlignTranslationFragmentsToYRC() lyric)  ytlrc缺行

### DIFF
--- a/internal/lyric/service.go
+++ b/internal/lyric/service.go
@@ -224,8 +224,10 @@ func (s *Service) SetSong(ctx context.Context, song structs.Song) error {
 			s.yrcLines = yrcLines
 
 			// Optionally align translation and roman lyrics to YRC
-			if s.showTranslation && lrcData.Ytlrc != "" {
-				s.yrcLines = AlignTranslationToYRC(s.yrcLines, lrcData.Ytlrc)
+			//ytlrc有缺行现象
+			//as まふまふ的单曲《猛独が襲う》: https://music.163.com/m/song?id=524152942 (来自@网易云音乐)
+			if s.showTranslation && lrcData.Translated != "" {
+				s.yrcLines = AlignTranslationFragmentsToYRC(s.fragments, s.yrcLines, s.transFragments)
 			}
 			if lrcData.Yromalrc != "" {
 				s.yrcLines = AlignRomanToYRC(s.yrcLines, lrcData.Yromalrc)
@@ -297,7 +299,7 @@ func (s *Service) EnableTranslation(enable bool) {
 				s.yrcLines = AlignTranslationToYRC(s.yrcLines, s.lastLRCData.Ytlrc)
 			} else if len(s.transFragments) > 0 {
 				// Fallback when no ytlrc
-				s.yrcLines = AlignTranslationFragmentsToYRC(s.yrcLines, s.transFragments)
+				s.yrcLines = AlignTranslationFragmentsToYRC(s.fragments, s.yrcLines, s.transFragments)
 			}
 		}
 	} else {

--- a/internal/lyric/yrc.go
+++ b/internal/lyric/yrc.go
@@ -313,16 +313,48 @@ func AlignRomanToYRC(yrcLines []YRCLine, romanLRC string) []YRCLine {
 
 // AlignTranslationFragmentsToYRC 将已解析的 LRC 翻译片段（timeMs->text）合并到 YRC 行中。
 // 用于没有 ytlrc，仅有传统 tlyric 的回退场景。
-func AlignTranslationFragmentsToYRC(yrcLines []YRCLine, transFragments map[int64]string) []YRCLine {
+func AlignTranslationFragmentsToYRC(fragments []LRCFragment, yrcLines []YRCLine, transFragments map[int64]string) []YRCLine {
 	if len(transFragments) == 0 || len(yrcLines) == 0 {
 		return yrcLines
 	}
+	type processedFrag struct {
+		content string
+		timeMs  int64
+	}
+	procFragments := make([]processedFrag, len(fragments))
+	for i, frag := range fragments {
+		content := strings.TrimSpace(frag.Content)
+		content = strings.TrimPrefix(content, "\ufeff")
+		procFragments[i] = processedFrag{content: content, timeMs: frag.StartTimeMs}
+	}
 
 	for i := range yrcLines {
-		if trans, ok := transFragments[yrcLines[i].StartTime]; ok && trans != "" {
-			yrcLines[i].TranslatedLyric = trans
+		var sb strings.Builder
+		for _, w := range yrcLines[i].Words {
+			sb.WriteString(w.Word)
+		}
+		lineText := strings.TrimSpace(sb.String())
+		lineText = strings.TrimPrefix(lineText, "\ufeff")
+
+		if lineText == "" {
+			continue
+		}
+
+		var matchedTime int64 = -1
+		for _, frag := range procFragments {
+			if frag.content != "" && (lineText == frag.content || strings.Contains(frag.content, lineText) || strings.Contains(lineText, frag.content)) {
+				matchedTime = frag.timeMs
+				break
+			}
+		}
+
+		if matchedTime != -1 {
+			if trans, ok := transFragments[matchedTime]; ok && trans != "" {
+				yrcLines[i].TranslatedLyric = trans
+			}
 		}
 	}
+
 	return yrcLines
 }
 


### PR DESCRIPTION
1 ytlrc有缺行现象
まふまふ的单曲《猛独が襲う》: https://music.163.com/m/song?id=524152942 (来自@网易云音乐)
2 AlignTranslationFragmentsToYRC函数无法正常工作

### Issue for this PR / 本 PR 关联的 Issue

Closes #657

---

### Type of change / 变更类型

- [x] Bug fix / Bug 修复
- [ ] New feature / 新功能
- [ ] Refactor | code improvement / 重构 | 代码优化
- [ ] Documentation / 文档更新

---

### What does this PR do? / 本 PR 做了什么？

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

请描述你修复的问题、所做的更改以及为什么这些更改有效。请确保你理解自己代码的工作原理，如果你不确定某些部分，也请如实说明，以便维护者了解代码的价值。
1更换为AlignTranslationFragmentsToYRC调用transFragments
2
遍历合并 yrcLines的单行 与fragments的行匹配
将 fragments的StartTimeMs content 提取
content 与 yrcLines 对比 
将对应的StartTimeMs的transFragments的词提取到TranslatedLyric

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**
**如果你在这里粘贴一段明显由 AI 生成的大段描述，你的 PR 可能会被忽略或关闭！**

---

### How did you verify your code works? / 如何验证你的代码有效？

<!-- 请描述你如何测试你的更改，例如：运行了哪些测试、执行了什么命令等 / Describe how you tested your changes, e.g., which tests you ran, what commands you executed. -->
WEBKIT_DISABLE_COMPOSITING_MODE=1 go run cmd/musicfox.go --debug --verbose 4   2&>/tmp/logs/log                                                                                                                                                                     
---

### Screenshots / recordings / 截图 / 录屏

<!-- If this is a UI change, please include a screenshot or recording. -->
<!-- 如果这是 UI 更改，请提供截图或录屏。-->
之前
<img width="1920" height="1080" alt="5ACC5F9D2DDEB275C2C677ABD97CCE92" src="https://github.com/user-attachments/assets/597976c4-afc9-4b39-a552-f66fb96374bd" />
之后
<img width="1920" height="1080" alt="图片" src="https://github.com/user-attachments/assets/c6246982-dd7d-46a9-8c26-92186e6e3d83" />

---

### Checklist / 检查清单

- [x] I have tested my changes locally / 我已在本地测试了我的更改
- [x] I have not included unrelated changes in this PR / 本 PR 未包含无关的更改

---

_If you do not follow this template your PR will be automatically rejected._
_如果不按照此模板填写，你的 PR 可能会被自动关闭。_
