### PR TITLE
fix(lyric): keep loading cancellable and responsive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,8 @@ type Player interface {
 
 ### 其他模块
 
-- **歌词**：LRC/YRC 格式，支持 smooth/wave/glow 渲染模式；未匹配的云盘歌曲（含旧播放快照）优先通过云盘歌词接口获取内嵌歌词，失败时回退普通歌曲歌词接口
+- **歌词**：LRC/YRC 格式，支持 smooth/wave/glow 渲染模式；未匹配的云盘歌曲（含旧播放快照）优先通过云盘歌词接口获取内嵌歌词，失败时回退普通歌曲歌词接口；`lyric.Service.LoadSong` 在调用线程登记请求并取消上次加载，再异步获取歌词，`SetSong` 保留同步接口。网络获取不持有状态锁，提交前检查取消状态，防止过期结果（含相同歌曲 ID 的旧请求）覆盖新歌词；`Stop` 取消加载并清空状态，播放器关闭时调用它。`track.Manager.GetLyric` 通过 `singleflight.DoChan` 合并请求，调用方可独立取消等待；共享请求使用 `context.WithoutCancel`，当前 SDK 不支持中断底层 HTTP 请求，共享请求继续至完成或 SDK 超时。歌词解析仍在状态锁内使用最新配置。
+- **Track 构造与测试**：`track.NewManager` 先应用选项，再补齐未指定的下载/歌词目录。隔离测试需同时注入下载目录、歌词目录及缓存实例，避免触发全局配置和用户目录初始化。
 - **播放列表**：列表循环/顺序/单曲循环/随机/无限随机/智能心动模式
 - **远程控制**：MPRIS(linux)、Now Playing(macOS)、System Media(Windows)。macOS 侧 `internal/macdriver/mediaplayer` 与 `internal/macdriver/cocoa/unnotifications.go` 的框架加载（Dlopen）失败不 panic 静默降级：MediaPlayer.framework 需 macOS 10.12.2+、UserNotifications.framework 需 10.14+，旧系统上 class 查找得 nil、objc 消息发送安全返回 0，对应功能（Now Playing 远程控制/系统通知）自动禁用而不影响主应用启动
 - **状态栏组件**：`model.DefaultStatusBar.Components` 可注入任意 `StatusBarComponent` 到居中区域；展示项只实现 `View`，可点击项额外实现 `InteractiveStatusBarComponent`，以自身局部坐标处理命中和事件。状态栏负责布局、边界与指针，不持有业务回调。播放队列适配器的 `musicfox` 前缀自行打开 `https://github.com/go-musicfox/go-musicfox`，队列位置与音质文本不触发。

--- a/internal/lyric/service.go
+++ b/internal/lyric/service.go
@@ -9,8 +9,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-musicfox/go-musicfox/internal/structs"
 	"github.com/pkg/errors"
+
+	"github.com/go-musicfox/go-musicfox/internal/structs"
+	"github.com/go-musicfox/go-musicfox/utils/errorx"
 )
 
 func min(a, b int) int {
@@ -78,7 +80,8 @@ type Service struct {
 	offset          time.Duration
 	skipParseErr    bool
 
-	mu sync.RWMutex
+	mu         sync.RWMutex
+	loadCancel context.CancelFunc
 }
 
 // NewService creates a new lyric service.
@@ -95,14 +98,54 @@ func NewService(fetcher Fetcher, showTranslation bool, initialOffset time.Durati
 	}
 }
 
-// SetSong loads lyrics for a new song.
+// LoadSong starts an asynchronous load. Register the request before starting the
+// goroutine so rapid track changes cannot reorder requests through scheduling.
+func (s *Service) LoadSong(ctx context.Context, song structs.Song) {
+	if ctx.Err() != nil {
+		return
+	}
+	ctx, cancel := s.beginLoad(ctx)
+	errorx.Go(func() {
+		defer cancel()
+		if err := s.loadSong(ctx, song); err != nil && !errors.Is(err, context.Canceled) {
+			slog.Debug("Failed to load lyrics", "songId", song.Id, "error", err)
+		}
+	}, true)
+}
+
+// SetSong loads lyrics synchronously, without holding the state lock during I/O.
 func (s *Service) SetSong(ctx context.Context, song structs.Song) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	ctx, cancel := s.beginLoad(ctx)
+	defer cancel()
+	return s.loadSong(ctx, song)
+}
+
+func (s *Service) beginLoad(ctx context.Context) (context.Context, context.CancelFunc) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.loadCancel != nil {
+		s.loadCancel()
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	s.loadCancel = cancel
+	s.resetState(true)
+	return ctx, cancel
+}
 
-	s.resetState(true) // Preserve configuration on reset
-
+func (s *Service) loadSong(ctx context.Context, song structs.Song) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	lrcData, err := s.fetcher.GetLyric(ctx, song)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// A canceled request must never publish, even if the fetcher ignored cancellation.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch lyric data")
 	}
@@ -348,6 +391,10 @@ func (s *Service) State() State {
 func (s *Service) Stop() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.loadCancel != nil {
+		s.loadCancel()
+		s.loadCancel = nil
+	}
 	s.resetState(false) // Full reset
 }
 

--- a/internal/lyric/service_loading_test.go
+++ b/internal/lyric/service_loading_test.go
@@ -1,0 +1,177 @@
+package lyric
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-musicfox/go-musicfox/internal/structs"
+)
+
+type lyricFetchFunc func(context.Context, structs.Song) (structs.LRCData, error)
+
+func (f lyricFetchFunc) GetLyric(ctx context.Context, song structs.Song) (structs.LRCData, error) {
+	return f(ctx, song)
+}
+
+func awaitLoad(t *testing.T, done <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(2 * time.Second):
+		t.Fatal("lyric operation blocked")
+		return nil
+	}
+}
+
+func TestStateRemainsResponsiveWhileLoading(t *testing.T) {
+	entered, release := make(chan struct{}), make(chan struct{})
+	defer close(release)
+	s := NewService(lyricFetchFunc(func(context.Context, structs.Song) (structs.LRCData, error) {
+		close(entered)
+		<-release
+		return structs.LRCData{Original: "[00:00.00]loaded"}, nil
+	}), false, 0, false)
+	done := make(chan error, 1)
+	go func() { done <- s.SetSong(context.Background(), structs.Song{Id: 1}) }()
+	<-entered
+	responsive := make(chan error, 1)
+	go func() {
+		s.State()
+		s.UpdatePosition(time.Second)
+		s.SetOffset(time.Second)
+		s.EnableTranslation(true)
+		responsive <- nil
+	}()
+	if err := awaitLoad(t, responsive); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLateLyricsCannotReplaceNewerRequest(t *testing.T) {
+	entered, release := make(chan struct{}), make(chan struct{})
+	var once sync.Once
+	unblock := func() { once.Do(func() { close(release) }) }
+	defer unblock()
+	calls := 0
+	s := NewService(lyricFetchFunc(func(context.Context, structs.Song) (structs.LRCData, error) {
+		calls++
+		if calls == 1 {
+			close(entered)
+			<-release
+			return structs.LRCData{Original: "[00:00.00]old"}, nil
+		}
+		return structs.LRCData{Original: "[00:00.00]new"}, nil
+	}), false, 0, false)
+	oldDone := make(chan error, 1)
+	go func() { oldDone <- s.SetSong(context.Background(), structs.Song{Id: 1}) }()
+	<-entered
+	newDone := make(chan error, 1)
+	// Repeat the same song ID: identity alone must not authorize an old result.
+	go func() { newDone <- s.SetSong(context.Background(), structs.Song{Id: 1}) }()
+	if err := awaitLoad(t, newDone); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.State().Fragments[0].Content; got != "new" {
+		t.Fatalf("lyric = %q", got)
+	}
+	// The old request must not publish even if its fetcher ignores cancellation.
+	unblock()
+	if err := awaitLoad(t, oldDone); !errors.Is(err, context.Canceled) {
+		t.Fatalf("old request error = %v", err)
+	}
+	if got := s.State().Fragments[0].Content; got != "new" {
+		t.Fatalf("late result replaced lyrics: %q", got)
+	}
+}
+
+func TestStopCancelsPendingLyrics(t *testing.T) {
+	entered := make(chan struct{})
+	s := NewService(lyricFetchFunc(func(ctx context.Context, _ structs.Song) (structs.LRCData, error) {
+		close(entered)
+		<-ctx.Done()
+		return structs.LRCData{Original: "[00:00.00]stale"}, nil
+	}), false, 0, false)
+	done := make(chan error, 1)
+	go func() { done <- s.SetSong(context.Background(), structs.Song{Id: 1}) }()
+	<-entered
+	stopped := make(chan error, 1)
+	go func() { s.Stop(); stopped <- nil }()
+	if err := awaitLoad(t, stopped); err != nil {
+		t.Fatal(err)
+	}
+	if err := awaitLoad(t, done); !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v", err)
+	}
+	if state := s.State(); state.IsRunning || len(state.Fragments) != 0 {
+		t.Fatalf("stopped state = %+v", state)
+	}
+}
+
+func TestLoadSongResetsSynchronouslyAndUsesCurrentOptions(t *testing.T) {
+	entered, release := make(chan struct{}), make(chan struct{})
+	var once sync.Once
+	unblock := func() { once.Do(func() { close(release) }) }
+	defer unblock()
+	s := NewService(lyricFetchFunc(func(_ context.Context, song structs.Song) (structs.LRCData, error) {
+		if song.Id == 2 {
+			close(entered)
+			<-release
+		}
+		return structs.LRCData{Original: "[00:00.00]original", Translated: "[00:00.00]translated"}, nil
+	}), false, 0, false)
+	if err := s.SetSong(context.Background(), structs.Song{Id: 1}); err != nil {
+		t.Fatal(err)
+	}
+	s.LoadSong(context.Background(), structs.Song{Id: 2})
+	if state := s.State(); state.IsRunning || len(state.Fragments) != 0 {
+		t.Fatalf("old lyrics visible after starting load: %+v", state)
+	}
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("asynchronous load did not start")
+	}
+	s.EnableTranslation(true)
+	s.SetOffset(250 * time.Millisecond)
+	unblock()
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		state := s.State()
+		if state.IsRunning {
+			if state.TranslatedFragments[0] != "translated" || state.OffsetMs != 250 || !state.ShowTranslation {
+				t.Fatalf("load discarded current options: %+v", state)
+			}
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatal("asynchronous load did not publish")
+		case <-ticker.C:
+		}
+	}
+}
+
+func TestCanceledSongDoesNotResetCurrentLyrics(t *testing.T) {
+	s := NewService(lyricFetchFunc(func(context.Context, structs.Song) (structs.LRCData, error) {
+		return structs.LRCData{Original: "[00:00.00]current"}, nil
+	}), false, 0, false)
+	if err := s.SetSong(context.Background(), structs.Song{Id: 1}); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := s.SetSong(ctx, structs.Song{Id: 2}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v", err)
+	}
+	s.LoadSong(ctx, structs.Song{Id: 2})
+	if state := s.State(); !state.IsRunning || len(state.Fragments) != 1 || state.Fragments[0].Content != "current" {
+		t.Fatalf("canceled load reset current lyrics: %+v", state)
+	}
+}

--- a/internal/track/manager.go
+++ b/internal/track/manager.go
@@ -55,13 +55,18 @@ type ManagerOption func(*Manager)
 // NewManager 创建一个新的 Manager 实例。
 func NewManager(opts ...ManagerOption) *Manager {
 	m := &Manager{
-		downloadDir: app.DownloadDir(),
-		lyricDir:    app.DownloadLyricDir(),
-		quality:     service.Standard, // 默认音质
+		quality: service.Standard, // 默认音质
 	}
 
 	for _, opt := range opts {
 		opt(m)
+	}
+
+	if m.downloadDir == "" {
+		m.downloadDir = app.DownloadDir()
+	}
+	if m.lyricDir == "" {
+		m.lyricDir = app.DownloadLyricDir()
 	}
 
 	if m.cacher == nil {
@@ -224,12 +229,18 @@ func (m *Manager) DownloadLyric(ctx context.Context, song structs.Song) (string,
 
 // GetLyric 获取一首歌的歌词。
 func (m *Manager) GetLyric(ctx context.Context, song structs.Song) (structs.LRCData, error) {
+	if err := ctx.Err(); err != nil {
+		return structs.LRCData{}, err
+	}
 	cloudUserID := m.cloudUserID.Load()
 	preferCloudLyric := shouldPreferCloudLyric(song)
 	key := fmt.Sprintf("lyric-fetch-%d-%d-%t", cloudUserID, song.Id, preferCloudLyric)
-	result, err, _ := m.sfGroup.Do(key, func() (any, error) {
+	// The shared request must outlive any one waiter. The SDK does not support
+	// transport cancellation; callers can independently stop waiting below.
+	fetchCtx := context.WithoutCancel(ctx)
+	resultCh := m.sfGroup.DoChan(key, func() (any, error) {
 		if preferCloudLyric && cloudUserID != 0 {
-			data, cloudErr := m.fetcher.FetchCloudLyric(ctx, cloudUserID, song.Id)
+			data, cloudErr := m.fetcher.FetchCloudLyric(fetchCtx, cloudUserID, song.Id)
 			if cloudErr == nil && data.Original != "" {
 				return data, nil
 			}
@@ -241,13 +252,21 @@ func (m *Manager) GetLyric(ctx context.Context, song structs.Song) (structs.LRCD
 					"songId", song.Id)
 			}
 		}
-		return m.fetcher.FetchLyric(ctx, song.Id)
+		return m.fetcher.FetchLyric(fetchCtx, song.Id)
 	})
 
-	if err != nil {
-		return structs.LRCData{}, err
+	select {
+	case <-ctx.Done():
+		return structs.LRCData{}, ctx.Err()
+	case result := <-resultCh:
+		if err := ctx.Err(); err != nil {
+			return structs.LRCData{}, err
+		}
+		if result.Err != nil {
+			return structs.LRCData{}, result.Err
+		}
+		return result.Val.(structs.LRCData), nil
 	}
-	return result.(structs.LRCData), nil
 }
 
 func shouldPreferCloudLyric(song structs.Song) bool {

--- a/internal/track/manager_lyric_test.go
+++ b/internal/track/manager_lyric_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-musicfox/go-musicfox/internal/structs"
 	"github.com/go-musicfox/go-musicfox/utils/netease"
@@ -152,5 +153,72 @@ func TestGetLyricKeepsRegularLyricsForMatchedCloudSong(t *testing.T) {
 	}
 	if fetcher.cloudCalls != 0 || fetcher.regularCalls != 1 {
 		t.Fatalf("fetch calls = (cloud %d, regular %d), want (0, 1)", fetcher.cloudCalls, fetcher.regularCalls)
+	}
+}
+
+// blockingLyricFetcher simulates an SDK request that cannot be interrupted.
+type blockingLyricFetcher struct {
+	*lyricFetcherStub
+	entered  chan context.Context
+	release  chan struct{}
+	finished chan struct{}
+}
+
+func (f *blockingLyricFetcher) FetchLyric(ctx context.Context, _ int64) (structs.LRCData, error) {
+	f.entered <- ctx
+	<-f.release
+	close(f.finished)
+	return structs.LRCData{Original: "[00:00.00]shared"}, nil
+}
+
+func TestGetLyricCancellationStopsWaiting(t *testing.T) {
+	f := &blockingLyricFetcher{
+		lyricFetcherStub: &lyricFetcherStub{},
+		entered:          make(chan context.Context, 1),
+		release:          make(chan struct{}),
+		finished:         make(chan struct{}),
+	}
+	defer close(f.release)
+	m := &Manager{fetcher: f}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { _, err := m.GetLyric(ctx, structs.Song{Id: 42}); done <- err }()
+	var sharedCtx context.Context
+	select {
+	case sharedCtx = <-f.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("request did not start")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancellation did not stop waiting")
+	}
+	if sharedCtx.Err() != nil {
+		t.Fatalf("caller canceled shared request: %v", sharedCtx.Err())
+	}
+	select {
+	case <-f.finished:
+		t.Fatal("request should still be blocked")
+	default:
+	}
+}
+
+func TestGetLyricAlreadyCanceledDoesNotFetch(t *testing.T) {
+	f := &lyricFetcherStub{}
+	m := &Manager{fetcher: f}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := m.GetLyric(ctx, structs.Song{Id: 42})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v", err)
+	}
+	if f.regularCalls != 0 || f.cloudCalls != 0 {
+		t.Fatal("canceled request fetched lyrics")
 	}
 }

--- a/internal/track/manager_persist_test.go
+++ b/internal/track/manager_persist_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestPersistStreamCorrectsSuffixByContent(t *testing.T) {
 	dir := t.TempDir()
-	m := NewManager(WithDownloadDir(dir))
+	m := NewManager(WithDownloadDir(dir), WithDownloadLyricDir(dir), WithCacher(&Cacher{}))
 
 	song := structs.Song{Id: 123, Name: "CloudSong", Artists: []structs.Artist{{Name: "Singer"}}}
 	fileName, err := m.nameGen.Song(song, "mp3")
@@ -44,7 +44,7 @@ func TestPersistStreamCorrectsSuffixByContent(t *testing.T) {
 
 func TestPersistStreamKeepsDeclaredSuffixWhenSniffUnknown(t *testing.T) {
 	dir := t.TempDir()
-	m := NewManager(WithDownloadDir(dir))
+	m := NewManager(WithDownloadDir(dir), WithDownloadLyricDir(dir), WithCacher(&Cacher{}))
 
 	song := structs.Song{Id: 456, Name: "CloudSong", Artists: []structs.Artist{{Name: "Singer"}}}
 	fileName, err := m.nameGen.Song(song, "mp3")

--- a/internal/ui/player.go
+++ b/internal/ui/player.go
@@ -295,9 +295,7 @@ func (p *Player) PlaySong(song structs.Song, direction PlayDirection) {
 		return
 	}
 
-	errorx.Go(func() {
-		p.lyricService.SetSong(context.Background(), song)
-	}, true)
+	p.lyricService.LoadSong(context.Background(), song)
 
 	p.Play(player.URLMusic{
 		URL:  url,
@@ -528,6 +526,7 @@ func (p *Player) Close() error {
 	p.reporter.ReportEnd(p.PlayedTime())
 
 	p.cancel()
+	p.lyricService.Stop()
 	if p.stateHandler != nil {
 		p.stateHandler.Release()
 	}

--- a/internal/ui/player_gapless.go
+++ b/internal/ui/player_gapless.go
@@ -103,7 +103,7 @@ func (p *Player) commitGaplessTransition(transition player.GaplessTransition) {
 	}
 	p.reporter.ReportEnd(transition.PlayedTime)
 	p.reporter.ReportStart(song)
-	errorx.Go(func() { p.lyricService.SetSong(context.Background(), song) }, true)
+	p.lyricService.LoadSong(context.Background(), song)
 	p.LocatePlayingSong()
 	p.stateHandler.SetPlayingInfo(p.PlayingInfo())
 	p.updateDesktopLyrics()


### PR DESCRIPTION
### Issue for this PR / 本 PR 关联的 Issue

无关联 Issue。基于 master 的 d4cf43dc 复现。

### Type of change / 变更类型

- [x] Bug fix / Bug 修复
- [ ] New feature / 新功能
- [ ] Refactor | code improvement / 重构 | 代码优化
- [ ] Documentation / 文档更新

### What does this PR do? / 本 PR 做了什么？

歌词获取期间，`SetSong` 持有状态写锁，慢请求会阻塞 `State` 和播放位置更新。改为锁外获取歌词；异步入口先登记请求，切歌或关闭时取消旧加载，提交前再次检查取消状态，防止迟到结果覆盖新歌词。

`GetLyric` 保留 singleflight 合并，并允许调用方独立取消等待。当前 SDK 不支持中断 HTTP 请求，因此共享请求仍会完成或超时。

同时修复回归测试基线：原有 `TestPersistStreamCorrectsSuffixByContent` 在全局配置为空时 panic。构造函数改为先应用选项，测试完整注入目录和缓存。

### How did you verify your code works? / 如何验证你的代码有效？

- 修复前：`go test ./internal/track` 复现空指针；新增阻塞 fetcher 测试复现状态读取超时。
- 修复后：`make test`、`make build`、`go test -race ./internal/lyric ./internal/track ./internal/ui` 通过。
- 新增 7 个测试覆盖加载响应性、迟到结果、停止与取消、异步加载及配置保留。
- golangci-lint v2.13.2 使用 `--modules-download-mode=vendor --new-from-rev=origin/master --whole-files=false` 检查本次改动，0 issues。
- 完整门禁未通过：默认 `make lint` 遇到依赖下载 EOF；vendor 模式的整文件检查仍报既有 errcheck/staticcheck 告警。全范围 `go vet` 另有既有 MPRIS Seek 签名告警。

### Screenshots / recordings / 截图 / 录屏

未改变界面布局；慢请求使用阻塞 fetcher 回归测试。尚未进行真实播放及 macOS/Windows 人工验证，仍需维护者进行对应 QA。

### Checklist / 检查清单

- [x] I have tested my changes locally / 我已在本地测试了我的更改
- [x] I have not included unrelated changes in this PR / 本 PR 未包含无关的更改
