### PR TITLE
fix(playlist): clamp currentPos in list-random mode

### DIFF
--- a/internal/playlist/list_random.go
+++ b/internal/playlist/list_random.go
@@ -40,6 +40,10 @@ func (l *ListRandomPlayMode) NextSong(currentIndex int, playlist []structs.Song,
 
 	// 如果超出范围，列表随机播放模式下停止播放
 	if l.currentPos >= len(l.randomOrder) {
+		// Clamp to the last position instead of leaving an out-of-range value,
+		// otherwise repeated NextSong calls keep drifting currentPos upward and
+		// a subsequent PreviousSong indexes randomOrder out of bounds.
+		l.currentPos = len(l.randomOrder) - 1
 		return -1, ErrNoNextSong
 	}
 
@@ -72,6 +76,10 @@ func (l *ListRandomPlayMode) PreviousSong(currentIndex int, playlist []structs.S
 
 	// 如果超出范围，列表随机播放模式下停止播放
 	if l.currentPos < 0 {
+		// Clamp to the first position instead of leaving a negative value,
+		// otherwise repeated PreviousSong calls keep drifting currentPos downward
+		// and a subsequent NextSong indexes randomOrder out of bounds.
+		l.currentPos = 0
 		return -1, ErrNoPreviousSong
 	}
 

--- a/internal/playlist/list_random_test.go
+++ b/internal/playlist/list_random_test.go
@@ -306,6 +306,83 @@ func TestListRandomPlayMode_RandomSequence(t *testing.T) {
 	}
 }
 
+func TestListRandomPlayMode_PreviousSongAfterExhaustedNext(t *testing.T) {
+	// 复现真实崩溃（v5.1.0）：列表随机模式播放完随机序列后，
+	// 连续按"下一曲"（每次返回 ErrNoNextSong），再按"上一曲"曾触发
+	// panic: index out of range [18] with length 17。
+	mode := NewListRandomPlayMode().(*ListRandomPlayMode)
+	playlist := createTestPlaylist(17)
+
+	if err := mode.Initialize(0, playlist); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	// 播完整个随机序列（NextSong 最终返回 ErrNoNextSong）
+	currentIndex := 0
+	for {
+		next, err := mode.NextSong(currentIndex, playlist, false)
+		if err != nil {
+			break
+		}
+		currentIndex = next
+	}
+
+	// 模拟用户连按"下一曲"（崩溃日志中观察到 2 次额外 ErrNoNextSong）
+	for i := 0; i < 2; i++ {
+		if _, err := mode.NextSong(currentIndex, playlist, true); err != ErrNoNextSong {
+			t.Fatalf("Expected ErrNoNextSong, got: %v", err)
+		}
+	}
+
+	// 按上一曲不应 panic，且返回有效索引
+	prevIndex, err := mode.PreviousSong(currentIndex, playlist, true)
+	if err != nil {
+		t.Fatalf("PreviousSong after exhausted NextSong returned error: %v", err)
+	}
+	if prevIndex < 0 || prevIndex >= len(playlist) {
+		t.Fatalf("PreviousSong returned invalid index %d", prevIndex)
+	}
+
+	// 状态完整性：currentPos 必须保持在随机序列范围内
+	if mode.currentPos < 0 || mode.currentPos >= len(mode.randomOrder) {
+		t.Fatalf("currentPos drifted out of range: %d (len=%d)", mode.currentPos, len(mode.randomOrder))
+	}
+}
+
+func TestListRandomPlayMode_NextSongAfterExhaustedPrevious(t *testing.T) {
+	// 镜像场景：回到随机序列开头后连按"上一曲"（currentPos 漂移为负），
+	// 再按"下一曲"同样会越界 panic: index out of range [-1]。
+	mode := NewListRandomPlayMode().(*ListRandomPlayMode)
+	playlist := createTestPlaylist(5)
+
+	if err := mode.Initialize(0, playlist); err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	// 回到序列开头，然后连按"上一曲"到越界
+	currentIndex := 0
+	mode.currentPos = 0
+	for i := 0; i < 3; i++ {
+		if _, err := mode.PreviousSong(currentIndex, playlist, true); err != ErrNoPreviousSong {
+			t.Fatalf("Expected ErrNoPreviousSong, got: %v", err)
+		}
+	}
+
+	// 按下一曲不应 panic，且返回有效索引
+	nextIndex, err := mode.NextSong(currentIndex, playlist, true)
+	if err != nil {
+		t.Fatalf("NextSong after exhausted PreviousSong returned error: %v", err)
+	}
+	if nextIndex < 0 || nextIndex >= len(playlist) {
+		t.Fatalf("NextSong returned invalid index %d", nextIndex)
+	}
+
+	// 状态完整性：currentPos 必须保持在随机序列范围内
+	if mode.currentPos < 0 || mode.currentPos >= len(mode.randomOrder) {
+		t.Fatalf("currentPos drifted out of range: %d (len=%d)", mode.currentPos, len(mode.randomOrder))
+	}
+}
+
 func TestListRandomPlayMode_PlaylistChangedRegeneration(t *testing.T) {
 	// 测试播放列表变化时重新生成随机序列
 	mode := NewListRandomPlayMode().(*ListRandomPlayMode)


### PR DESCRIPTION
NextSong/PreviousSong of ListRandomPlayMode returned out-of-range errors without rolling back currentPos, so the out-of-range value stayed in the state. Every repeated call kept drifting the cursor further out (e.g. pressing "next" after the random order finished), and the first navigation in the opposite direction then indexed randomOrder out of bounds and panicked:

    panic: runtime error: index out of range [18] with length 17

observed in ListRandomPlayMode.PreviousSong after the random order was exhausted and "next" was pressed twice more.

Clamp currentPos back to the last/first position before returning the error, which makes the error idempotent and lets navigation in the opposite direction resume normally. Add regression tests for both directions.

### Issue for this PR / 本 PR 关联的 Issue

https://github.com/go-musicfox/go-musicfox/issues/669

Closes #

---

### Type of change / 变更类型

- [x] Bug fix / Bug 修复
- [ ] New feature / 新功能
- [ ] Refactor | code improvement / 重构 | 代码优化
- [ ] Documentation / 文档更新

---

### What does this PR do? / 本 PR 做了什么？

增加限制避免 currentPos 越界

---

### How did you verify your code works? / 如何验证你的代码有效？

重复 issue 提到的操作不再崩溃

---

### Screenshots / recordings / 截图 / 录屏

<!-- If this is a UI change, please include a screenshot or recording. -->
<!-- 如果这是 UI 更改，请提供截图或录屏。-->

---

### Checklist / 检查清单

- [x] I have tested my changes locally / 我已在本地测试了我的更改
- [x] I have not included unrelated changes in this PR / 本 PR 未包含无关的更改

---

_If you do not follow this template your PR will be automatically rejected._
_如果不按照此模板填写，你的 PR 可能会被自动关闭。_
